### PR TITLE
Allow public access to TwilioUtils constructor

### DIFF
--- a/src/com/twilio/sdk/TwilioUtils.java
+++ b/src/com/twilio/sdk/TwilioUtils.java
@@ -44,7 +44,7 @@ public class TwilioUtils {
     protected String authToken;
     protected String accountSid;
     
-    TwilioUtils(String authToken, String accountSid){
+    public TwilioUtils(String authToken, String accountSid){
         this.authToken = authToken;
         this.accountSid = accountSid;
     }


### PR DESCRIPTION
Reported here: http://getsatisfaction.com/twilio/topics/java_twilioutils_constuctor_not_public?do=reply&utm_content=reply_link&utm_medium=email&utm_source=new_topic
