### PR TITLE
Delete unavailable properties of AuthorizedConnectApps

### DIFF
--- a/src/main/java/com/twilio/sdk/resource/instance/AuthorizedConnectApp.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/AuthorizedConnectApp.java
@@ -116,7 +116,7 @@ public class AuthorizedConnectApp extends InstanceResource {
 	 * 
 	 * @return the friendly name
 	 */
-	public String getConnectAppFriendlyName() {
+	public String getFriendlyName() {
 		return this.getProperty("connect_app_friendly_name");
 	}
 
@@ -136,6 +136,15 @@ public class AuthorizedConnectApp extends InstanceResource {
 	 */
 	public String getConnectAppDescription() {
 		return this.getProperty("connect_app_description");
+	}
+
+	/**
+	 * Get the connect app friendly name.
+	 *
+	 * @return the connect app friendly name
+	 */
+	public String getConnectAppFriendlyName() {
+		return this.getProperty("connect_app_friendly_name");
 	}
 
 	/**


### PR DESCRIPTION
The JSON response for an AuthorizedConnectApp looks like:

``` javascript
{
    "connect_app_sid": "CNf6f33caf42cf4c849b68fb4a1c6a868c", 
    "connect_app_friendly_name": "Pat Malatrack 1337225835286", 
    "connect_app_company_name": "Malatrack & Sons HVAC & Plumbing Services", 
    "uri": "/2010-04-01/Accounts/AC4811d370b91d47f099e75f4937aaad43/AuthorizedConnectApps/CNf6f33caf42cf4c849b68fb4a1c6a868c.json", 
    "account_sid": "AC4811d370b91d47f099e75f4937aaad43", 
    "connect_app_description": "The best plubming and hvac of alll time", 
    "connect_app_homepage_url": "http://www.lingscars.com/", 
    "permissions": [
        "get-all"
    ]
}
```

The AuthorizedConnectApp.java file contains getters for properties that do not exist such as the DateUpdated and DateCreated. In addition the naming convention for this file breaks with the naming for all other files, by shortening `connect_app_description` to getDescription instead of getConnectAppDescription. This makes automated code generation harder :(

I removed the getters for properties that don't exist, and added getters that match the rest of the library standard. It means we have two getters for the same property in some cases but that's probably better than breaking compatibility.
