### PR TITLE
Remove the unused accountSID field from TwilioUtils

### DIFF
--- a/src/main/java/com/twilio/sdk/TwilioUtils.java
+++ b/src/main/java/com/twilio/sdk/TwilioUtils.java
@@ -47,6 +47,11 @@ public class TwilioUtils {
         this.authToken = authToken;
     }
     
+    @Deprecated
+    public TwilioUtils(String authToken, String accountSid){
+    	this.authToken = authToken;
+    }
+    
     public boolean validateRequest(String expectedSignature, String url, Map<String,String> params){
         
         SecretKeySpec signingKey = new SecretKeySpec(this.authToken.getBytes(), "HmacSHA1");


### PR DESCRIPTION
There is no need for the account SID when validating requests.

(Also updated the copyright notice year)
