### PR TITLE
Allow library users to retrieve the hashed "X-Twilio-Signature" from TwilioUtils Library

### DIFF
--- a/src/main/java/com/twilio/sdk/TwilioUtils.java
+++ b/src/main/java/com/twilio/sdk/TwilioUtils.java
@@ -50,45 +50,54 @@ public class TwilioUtils {
     }
 
     public boolean validateRequest(String expectedSignature, String url, Map<String,String> params) {
-
-        SecretKeySpec signingKey = new SecretKeySpec(this.authToken.getBytes(), "HmacSHA1");
-
-        try {
-            //initialize the hash algortihm
-            Mac mac = Mac.getInstance("HmacSHA1");
-            mac.init(signingKey);
-
-            //sort the params alphabetically, and append the key and value of each to the url
-            StringBuffer data = new StringBuffer(url);
-            if (params != null) {
-                List<String> sortedKeys = new ArrayList<String>( params.keySet());
-                Collections.sort(sortedKeys);
-
-                for (String s: sortedKeys) {
-                    data.append(s);
-                    String v = "";
-                    if (params.get(s) != null) {
-                        v = params.get(s);
-                    }
-                    data.append(v);
-                }
-            }
-
-            //compute the hmac on input data bytes
-            byte[] rawHmac = mac.doFinal(data.toString().getBytes("UTF-8"));
-
-            //base64-encode the hmac
-            String signature = new String(Base64.encodeBase64(rawHmac));
-
-            return signature.equals(expectedSignature);
+        String signature = null;
+        
+        signature = getValidationSignature(url, params);
+        
+        if(signature == null) {
+        	return false;
+        } else {
+        	return signature.equals(expectedSignature);
+        }
+    }
+    
+    public String getValidationSignature(String url, Map<String,String> params) {
+    	SecretKeySpec signingKey = new SecretKeySpec(this.authToken.getBytes(), "HmacSHA1");
+   	
+    	try {
+	    	//initialize the hash algortihm
+	        Mac mac = Mac.getInstance("HmacSHA1");
+	        mac.init(signingKey);
+	
+	        //sort the params alphabetically, and append the key and value of each to the url
+	        StringBuffer data = new StringBuffer(url);
+	        if (params != null) {
+	            List<String> sortedKeys = new ArrayList<String>( params.keySet());
+	            Collections.sort(sortedKeys);
+	
+	            for (String s: sortedKeys) {
+	                data.append(s);
+	                String v = "";
+	                if (params.get(s) != null) {
+	                    v = params.get(s);
+	                }
+	                data.append(v);
+	            }
+	        }
+	
+	        //compute the hmac on input data bytes
+	        byte[] rawHmac = mac.doFinal(data.toString().getBytes("UTF-8"));
+	
+	        //base64-encode the hmac
+	        String signature = new String(Base64.encodeBase64(rawHmac));
+	
+	        return signature; 
         } catch (NoSuchAlgorithmException e) {
-
-            return false;
+            return null;
         } catch (InvalidKeyException e) {
-
-            return false;
+            return null;
         } catch (UnsupportedEncodingException e) {
-            return false;
+            return null;
         }
     }
 }


### PR DESCRIPTION
I added a method "getValidationSignature" to the TwilioUtils class and re-routed the validateRequest to use it (i.e. moved the old logic into the new method).  I also moved all exception handling into the new method, which will return null in these cases (and validateRequest will return false if getValidationSignature returns null).

This new method could be renamed to something else depending on your preference.  The purpose is to return the hashed signature string.

We needed to know this string at my company in order to create a mock request for integration testing, and we resorted to cutting and pasting the logic from validateRequest for the time being.  

It would be better housed in a method for our usage, especially if the hashing algorithm changes in the future.

Thanks and keep up the great work!
