### PR TITLE
Add Travis CI build status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/twilio/twilio-java.png?branch=master)](https://travis-ci.org/twilio/twilio-java)
+
 # Installing 
 
 TwilioJava is now using Maven.  At present the jars *are* available from a public [maven](http://maven.apache.org/download.html) repository. 


### PR DESCRIPTION
It's hooked up to Travis anyways, might as well show off the badge. Would also encourage more tests.

It would be cool if builds on pull-requests were enabled too, very useful.
