### PR TITLE
change the GET test to use https instead of http

### DIFF
--- a/src/test/java/com/twilio/sdk/TwilioRestClientTest.java
+++ b/src/test/java/com/twilio/sdk/TwilioRestClientTest.java
@@ -88,7 +88,7 @@ public class TwilioRestClientTest {
 				"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
 		
 		// Auth required
-		TwilioRestResponse response = client.get("http://api.twilio.com");	
+		TwilioRestResponse response = client.get("https://api.twilio.com");	
 		assertEquals(200, response.getHttpStatus());
 	}
 


### PR DESCRIPTION
We should be using ssl for accessing api.twilio.com for the GET test.
