### PR TITLE
Expose getObject() in InstanceResource

### DIFF
--- a/src/main/java/com/twilio/sdk/resource/InstanceResource.java
+++ b/src/main/java/com/twilio/sdk/resource/InstanceResource.java
@@ -75,6 +75,12 @@ public abstract class InstanceResource extends Resource {
 				+ " is an object.  Use getObject() instead.");
 	}
 
+  /**
+   * Gets the property as an Object.
+   *
+   * @param name the name of the property
+   * @return the property as an Object
+   */
 	public Object getObject(String name) {
 	    	Object prop = getAndLoadIfNecessary(name);
 


### PR DESCRIPTION
Fixes #98 by exposing the getObject() method in InstanceResource and adds documentation.
