### PR TITLE
The Dial verb should allow the Sip verb to be embedded

### DIFF
--- a/src/main/java/com/twilio/sdk/verbs/Dial.java
+++ b/src/main/java/com/twilio/sdk/verbs/Dial.java
@@ -47,7 +47,8 @@ public class Dial extends Verb {
         this.allowedVerbs.add(Verb.V_CONFERENCE);
         this.allowedVerbs.add(Verb.V_CLIENT);
         this.allowedVerbs.add(Verb.V_QUEUE);
-        this.allowedVerbs.add(Verb.V_SIP);   
+        this.allowedVerbs.add(Verb.V_SIP);
+        
     }
 
     /**


### PR DESCRIPTION
Hi, I was in Twilio training two days back and noticed that the Dial verb does not allow the Sip verb to be appended. Here is a fix for your review.
