### PR TITLE
Use correct value times for Queue Member

### DIFF
--- a/src/main/java/com/twilio/sdk/resource/instance/Member.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/Member.java
@@ -113,8 +113,8 @@ public class Member extends InstanceResource {
      *
      * @return the wait time as a String
      */
-    public String getWaitTime() {
-        return this.getProperty(Member.WAIT_TIME);
+    public Integer getWaitTime() {
+        return (Integer) this.getObject(Member.WAIT_TIME);
     }
 
     /**
@@ -122,8 +122,8 @@ public class Member extends InstanceResource {
      *
      * @return the position as a String
      */
-    public String getPosition() {
-        return this.getProperty(Member.POSITION);
+    public Integer getPosition() {
+        return (Integer) this.getObject(Member.POSITION);
     }
 
     /**

--- a/src/test/java/com/twilio/sdk/resource/instance/MemberTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/MemberTest.java
@@ -3,6 +3,7 @@ package com.twilio.sdk.resource.instance;
 import com.twilio.sdk.TwilioRestClient;
 import com.twilio.sdk.TwilioRestException;
 import com.twilio.sdk.TwilioRestResponse;
+
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -43,9 +44,9 @@ public class MemberTest {
 
         map.put("call_sid", callSid);
         map.put("queue_sid", queueSid);
-        map.put("position", "1");
+        map.put("position", 1);
         map.put("date_enqueued", formattedDate);
-        map.put("wait_time", "10");
+        map.put("wait_time", 10);
 
     }
 
@@ -65,9 +66,9 @@ public class MemberTest {
         Member m = new Member(client, queueSid, callSid);
         m.setRequestAccountSid(accountSid);
 
-        assertTrue(m.getPosition().equals("1"));
+        assertTrue(m.getPosition() == 1);
         assertTrue(dateFormat.format(m.getDateEnqueued()).equals(formattedDate));
-        assertTrue(m.getWaitTime().equals("10"));
+        assertTrue(m.getWaitTime() == 10);
     }
 
     /**
@@ -83,15 +84,15 @@ public class MemberTest {
                 client.safeRequest(Matchers.eq("/2010-04-01/Accounts/" + accountSid + "/Queues/" + queueSid
                         + "/Members/" + callSid + ".json"), Matchers.eq("POST"), Matchers.any(Map.class)))
                 .toReturn(resp);
-       final Member m = new Member(client, queueSid, callSid);
+        final Member m = new Member(client, queueSid, callSid);
         m.setRequestAccountSid(accountSid);
         final String method = "GET";
         final String url = "http://www.example.com";
         final Member newm = m.dequeue(url, method);
 
-        assertTrue(newm.getPosition().equals("1"));
+        assertTrue(newm.getPosition() == 1);
         assertTrue(dateFormat.format(newm.getDateEnqueued()).equals(formattedDate));
-        assertTrue(newm.getWaitTime().equals("10"));
+        assertTrue(newm.getWaitTime() == 10);
     }
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/QueueTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/QueueTest.java
@@ -88,9 +88,9 @@ public class QueueTest {
 		formattedDate = dateFormat.format(new Date());
 		map.put("call_sid", callSid);
 		map.put("queue_sid", queueSid);
-		map.put("position", "1");
+		map.put("position", 1);
 		map.put("date_enqueued", formattedDate);
-		map.put("wait_time", "10");
+		map.put("wait_time", 10);
 
 		stub(
 				client.safeRequest(Matchers.eq("/2010-04-01/Accounts/" + accountSid + "/Queues/" + queueSid
@@ -103,9 +103,9 @@ public class QueueTest {
 		String url = "http://www.example.com";
 		Member m = q.dequeueHeadOfQueue(url, method);
 
-		assertTrue(m.getPosition().equals("1"));
+		assertTrue(m.getPosition() == 1);
 		assertTrue(dateFormat.format(m.getDateEnqueued()).equals(formattedDate));
-		assertTrue(m.getWaitTime().equals("10"));
+		assertTrue(m.getWaitTime() == 10);
 	}
 
 	/**


### PR DESCRIPTION
Currently the getWaitTime and getPosition methods on Member throw exceptions for every call because they are returned as ints and not Strings.

This corrects that and updates the tests to reflect.
