### PR TITLE
Make sure children are escaped properly in TwiML XML

### DIFF
--- a/src/main/java/com/twilio/sdk/verbs/Verb.java
+++ b/src/main/java/com/twilio/sdk/verbs/Verb.java
@@ -160,7 +160,7 @@ public class Verb {
             xml += body;
         }
         for (Verb child : children){
-            xml += child.toXML();
+            xml += child.toXML(escape);
         }
         return xml += "</" + this.tag + ">";
     }


### PR DESCRIPTION
Currently ```.toEscapedXML()``` or ```.toXML(true)``` only escapes the root body and not its children. This PR will also escape the verb's children.