### PR TITLE
Added support for 'record' verb attribute to enable / disable recording both legs both legs of a call within the associated <Dial> verb

### DIFF
--- a/src/main/java/com/twilio/sdk/verbs/Dial.java
+++ b/src/main/java/com/twilio/sdk/verbs/Dial.java
@@ -95,7 +95,34 @@ public class Dial extends Verb {
         else
             this.set("hangupOnStar", "false");          
     }
-    
+
+    /**
+     * Sets the record behavior.
+     *
+     * <ul>
+     *     <li>do-not-record        - don't record</li>
+     *     <li>record-from-answer   - the recording will begin when a call is answered</li>
+     *     <li>record-from-ringing  - the recording will begin when the ringing starts</li>
+     * </ul>
+     *
+     * @param value the new record value
+     */
+    public void setRecord(String value) {
+        this.set("record", value);
+    }
+
+    /**
+     * Set the record behavior (Legacy way).
+     *
+     * @param f whether or not ro record
+     */
+    public void setRecord(boolean f) {
+        if (f)
+            this.set("record", "true");
+        else
+            this.set("record", "false");
+    }
+
     /**
      * Sets the time limit.
      *


### PR DESCRIPTION
See the [TwiML documentation](https://www.twilio.com/docs/api/twiml/dial) which describes the recording feature