### PR TITLE
upgrade to commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
 
     <!-- Commons -->
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.3.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/twilio/sdk/CapabilityToken.java
+++ b/src/main/java/com/twilio/sdk/CapabilityToken.java
@@ -1,7 +1,7 @@
 package com.twilio.sdk;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONValue;
 
 import javax.crypto.Mac;

--- a/src/main/java/com/twilio/sdk/client/TwilioCapability.java
+++ b/src/main/java/com/twilio/sdk/client/TwilioCapability.java
@@ -1,6 +1,6 @@
 package com.twilio.sdk.client;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;

--- a/src/main/java/com/twilio/sdk/verbs/Verb.java
+++ b/src/main/java/com/twilio/sdk/verbs/Verb.java
@@ -26,7 +26,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;


### PR DESCRIPTION
This PR uses a more up to date version of commons-lang (3.x), there are no deep changes but it would allow to avoid having commons-lang 2.x coming through maven transitive dependencies.