### PR TITLE
add access to notifications subresource from a call

### DIFF
--- a/src/main/java/com/twilio/sdk/resource/instance/Call.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/Call.java
@@ -8,6 +8,7 @@ import com.twilio.sdk.resource.factory.FeedbackFactory;
 import com.twilio.sdk.resource.factory.impl.FeedbackFactoryImpl;
 import com.twilio.sdk.resource.list.RecordingList;
 import com.twilio.sdk.resource.list.TranscriptionList;
+import com.twilio.sdk.resource.list.NotificationList;
 import org.apache.http.NameValuePair;
 
 import java.util.Date;
@@ -101,6 +102,17 @@ public class Call extends InstanceResource<TwilioRestClient> {
 		RecordingList recordings = new RecordingList(this.getClient(), this.getSid());
 		recordings.setRequestAccountSid(this.getRequestAccountSid());
 		return recordings;
+	}
+
+	/**
+	 * Returns the list of associated notifications
+	 *
+	 * @return the NotificationList associated this this call
+	 */
+	public NotificationList getNotifications() {
+		NotificationList notifications = new NotificationList(this.getClient(), this.getSid());
+		notifications.setRequestAccountSid(this.getRequestAccountSid());
+		return notifications;
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/resource/list/NotificationList.java
+++ b/src/main/java/com/twilio/sdk/resource/list/NotificationList.java
@@ -14,6 +14,8 @@ import java.util.Map;
  */
 public class NotificationList extends ListResource<Notification, TwilioRestClient> {
 
+	private String requestCallSid;
+
 	/**
 	 * Instantiates a new notification list.
 	 *
@@ -21,6 +23,29 @@ public class NotificationList extends ListResource<Notification, TwilioRestClien
 	 */
 	public NotificationList(TwilioRestClient client) {
 		super(client);
+	}
+
+	/**
+	 * Instantiates a new notification list.
+	 *
+	 * @param client the client
+	 * @param callSid the sid of the parent call
+	 */
+	public NotificationList(TwilioRestClient client, String callSid) {
+		super(client);
+		this.requestCallSid = callSid;
+	}
+
+	/**
+	 * Instantiates a new notification list.
+	 *
+	 * @param client the client
+	 * @param callSid the sid of the parent call
+	 * @param filters the filters
+	 */
+	public NotificationList(TwilioRestClient client, String callSid, Map<String, String> filters) {
+		super(client, filters);
+		this.requestCallSid = callSid;
 	}
 
 	/**
@@ -38,8 +63,15 @@ public class NotificationList extends ListResource<Notification, TwilioRestClien
 	 */
 	@Override
 	protected String getResourceLocation() {
-		return "/" + TwilioRestClient.DEFAULT_VERSION + "/Accounts/"
-				+ this.getRequestAccountSid() + "/Notifications.json";
+		if (this.requestCallSid != null) {
+			return "/" + TwilioRestClient.DEFAULT_VERSION +
+				"/Accounts/" + this.getRequestAccountSid() +
+				"/Calls/" + this.getRequestCallSid() +
+				"/Notifications.json";
+		} else {
+			return "/" + TwilioRestClient.DEFAULT_VERSION + "/Accounts/"
+					+ this.getRequestAccountSid() + "/Notifications.json";
+		}
 	}
 
 	/* (non-Javadoc)
@@ -57,5 +89,15 @@ public class NotificationList extends ListResource<Notification, TwilioRestClien
 	@Override
 	protected String getListKey() {
 		return "notifications";
+	}
+
+	/**
+	 * Gets the call sid of the notification *if* it was initially referenced
+	 * as the child of a message
+	 *
+	 * @return the call sid of the parent call
+	 */
+	public String getRequestCallSid() {
+		return this.requestCallSid;
 	}
 }

--- a/src/test/java/com/twilio/sdk/resource/list/NotificationListTest.java
+++ b/src/test/java/com/twilio/sdk/resource/list/NotificationListTest.java
@@ -1,0 +1,41 @@
+package com.twilio.sdk.resource.list;
+
+import com.twilio.sdk.TwilioRestClient;
+import com.twilio.sdk.resource.instance.Call;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+public class NotificationListTest {
+
+	private static final String CALL_SID = "CA12345678901234567890123456789012";
+
+	private static final TwilioRestClient CLIENT = mock(TwilioRestClient.class);
+
+	@Test
+	public void testCallNotificationListTwilioRestClientString() {
+		NotificationList notifications = new NotificationList(CLIENT, CALL_SID);
+		assertNotNull(notifications);
+		assertEquals(CALL_SID, notifications.getRequestCallSid());
+	}
+
+	@Test
+	public void testCallNotificationListTwilioRestClientStringStringMap() {
+		NotificationList notifications = new NotificationList(CLIENT, CALL_SID, new HashMap<String, String>());
+		assertNotNull(notifications);
+		assertEquals(CALL_SID, notifications.getRequestCallSid());
+	}
+
+	@Test
+	public void testCallGetNotifications() {
+		Call call = new Call(CLIENT, CALL_SID);
+		NotificationList notifications = call.getNotifications();
+		assertNotNull(notifications);
+		assertEquals(CALL_SID, notifications.getRequestCallSid());
+	}
+
+}


### PR DESCRIPTION
This has been in the API for some time but wasn't possible through this library.

Usage:

```
NotificationList notifications = call.getNotifications();
```