### PR TITLE
Remove getNumPages() from ListResource

### DIFF
--- a/src/main/java/com/twilio/sdk/resource/ListResource.java
+++ b/src/main/java/com/twilio/sdk/resource/ListResource.java
@@ -141,15 +141,6 @@ public abstract class ListResource<T extends Resource, C extends TwilioClient> e
 	}
 
 	/**
-	 * Gets the num pages.
-	 *
-	 * @return the num pages
-	 */
-	public int getNumPages() {
-		return numPages;
-	}
-
-	/**
 	 * Gets the page.
 	 *
 	 * @return the page


### PR DESCRIPTION
Apparently we missed this one in the count-deprecation cleanup.
@ihumanable @dougblack 