### PR TITLE
Fix of the 'statusCallbackEvents' for Client and Number verbs

### DIFF
--- a/src/main/java/com/twilio/sdk/verbs/Client.java
+++ b/src/main/java/com/twilio/sdk/verbs/Client.java
@@ -97,7 +97,7 @@ public class Client extends Verb {
 	 * @param events Events to provide callbacks for.
 	 */
 	public void setStatusCallbackEvents(String events) {
-		this.set("statusCallbackEvents", events);
+		this.set("statusCallbackEvent", events);
 	}
 }
 

--- a/src/main/java/com/twilio/sdk/verbs/Number.java
+++ b/src/main/java/com/twilio/sdk/verbs/Number.java
@@ -106,7 +106,7 @@ public class Number extends Verb {
 	 * @param events Events to provide callbacks for.
 	 */
 	public void setStatusCallbackEvents(String events) {
-		this.set("statusCallbackEvents", events);
+		this.set("statusCallbackEvent", events);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/verbs/ClientTest.java
+++ b/src/test/java/com/twilio/sdk/verbs/ClientTest.java
@@ -15,7 +15,7 @@ public class ClientTest {
 		client.setStatusCallback("http://example.com");
 		client.setStatusCallbackMethod("POST");
 		client.setStatusCallbackEvents("ringing completed");
-		assertEquals("<Client statusCallback=\"http://example.com\" statusCallbackMethod=\"POST\" statusCallbackEvents=\"ringing completed\">client:foobar</Client>",
+		assertEquals("<Client statusCallback=\"http://example.com\" statusCallbackMethod=\"POST\" statusCallbackEvent=\"ringing completed\">client:foobar</Client>",
 				client.toXML());
 	}
 }

--- a/src/test/java/com/twilio/sdk/verbs/NumberTest.java
+++ b/src/test/java/com/twilio/sdk/verbs/NumberTest.java
@@ -15,7 +15,7 @@ public class NumberTest {
 		number.setStatusCallback("http://example.com");
 		number.setStatusCallbackMethod("POST");
 		number.setStatusCallbackEvents("ringing completed");
-		assertEquals("<Number statusCallback=\"http://example.com\" statusCallbackMethod=\"POST\" statusCallbackEvents=\"ringing completed\">+15108675309</Number>",
+		assertEquals("<Number statusCallback=\"http://example.com\" statusCallbackMethod=\"POST\" statusCallbackEvent=\"ringing completed\">+15108675309</Number>",
 				number.toXML());
 	}
 }


### PR DESCRIPTION
Fixes incorrect name of the generated attribute - statusCallbackEvents - to a singular form. This is a continuation of #210 and it partially fixes DEVX-1997.