### PR TITLE
sendSms() and tidy up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>twilio-java-sdk</artifactId>
   <packaging>jar</packaging>
   <name>twilio-java-sdk</name>
-  <version>4.4.5-SNAPSHOT</version>
+  <version>4.4.5</version>
   <description>Java helper library for Twilio services</description>
   <url>http://www.twilio.com</url>
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>twilio-java-sdk</artifactId>
   <packaging>jar</packaging>
   <name>twilio-java-sdk</name>
-  <version>4.4.5</version>
+  <version>4.4.6-SNAPSHOT</version>
   <description>Java helper library for Twilio services</description>
   <url>http://www.twilio.com</url>
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -141,29 +141,29 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.8</version>
-        <configuration>
-          <show>public</show>
-          <nohelp>true</nohelp>
-          <author>true</author>
-          <version>true</version>
-          <use>true</use>
-          <windowtitle>Twilio Java</windowtitle>
-          <doctitle><![CDATA[<h1>Twilio Java</h1>]]></doctitle>
-          <bottom><![CDATA[<i>Copyright &#169; 2011 Twilio, Inc. All Rights Reserved.</i>]]></bottom>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-javadoc-plugin</artifactId>-->
+        <!--<version>2.8</version>-->
+        <!--<configuration>-->
+          <!--<show>public</show>-->
+          <!--<nohelp>true</nohelp>-->
+          <!--<author>true</author>-->
+          <!--<version>true</version>-->
+          <!--<use>true</use>-->
+          <!--<windowtitle>Twilio Java</windowtitle>-->
+          <!--<doctitle><![CDATA[<h1>Twilio Java</h1>]]></doctitle>-->
+          <!--<bottom><![CDATA[<i>Copyright &#169; 2011 Twilio, Inc. All Rights Reserved.</i>]]></bottom>-->
+        <!--</configuration>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<id>attach-sources</id>-->
+            <!--<goals>-->
+              <!--<goal>jar</goal>-->
+            <!--</goals>-->
+          <!--</execution>-->
+        <!--</executions>-->
+      <!--</plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/com/twilio/sdk/ITwilioClient.java
+++ b/src/main/java/com/twilio/sdk/ITwilioClient.java
@@ -1,0 +1,11 @@
+package com.twilio.sdk;
+
+import com.twilio.sdk.pojo.SMSCriteria;
+
+/**
+ * Created by will on 06/02/2016.
+ */
+public interface ITwilioClient {
+
+    TwilioRestResponse sendSms(SMSCriteria smsCriteria) throws TwilioRestException;
+}

--- a/src/main/java/com/twilio/sdk/LookupsClient.java
+++ b/src/main/java/com/twilio/sdk/LookupsClient.java
@@ -9,12 +9,13 @@ public class LookupsClient extends TwilioClient {
 
 	public static final String DEFAULT_VERSION = "v1";
 
-	public LookupsClient(final String accountSid, final String authToken) {
-		super(accountSid, authToken, "https://lookups.twilio.com");
+	@Override
+	public String getEndpoint(){
+		return "https://lookups.twilio.com";
 	}
 
-	public LookupsClient(final String accountSid, final String authToken, final String endpoint) {
-		super(accountSid, authToken, endpoint);
+	public LookupsClient(final String accountSid, final String authToken) {
+		super(accountSid, authToken);
 	}
 
 	public PhoneNumber getPhoneNumber(final String number) {

--- a/src/main/java/com/twilio/sdk/TwilioClient.java
+++ b/src/main/java/com/twilio/sdk/TwilioClient.java
@@ -35,7 +35,7 @@ import java.util.*;
 /**
  * The abstract class TwilioClient.
  */
-public abstract class TwilioClient {
+public abstract class TwilioClient implements ITwilioClient {
 
 	/**
 	 * The default HTTP Connection timeout

--- a/src/main/java/com/twilio/sdk/TwilioClient.java
+++ b/src/main/java/com/twilio/sdk/TwilioClient.java
@@ -30,6 +30,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -354,7 +355,7 @@ public abstract class TwilioClient {
 	}
 
 	public TwilioRestResponse request(final String path, final String method,
-	                                  final List<NameValuePair> paramList) throws TwilioRestException {
+	                                  final List<NameValuePair> paramList) {
 
 		HttpUriRequest request = setupRequest(path, method, paramList);
 
@@ -506,7 +507,7 @@ public abstract class TwilioClient {
 		for (int retry = 0; retry < numRetries; retry++) {
 			response = request(path, method, paramList);
 			if (response.isClientError()) {
-				throw TwilioRestException.parseResponse(response);
+				response.buildAndThrowTwilioRestException();
 			} else if (response.isServerError()) {
 				try {
 					Thread.sleep(100 * retry); // Backoff on our sleep
@@ -519,6 +520,50 @@ public abstract class TwilioClient {
 		}
 		int errorCode = response == null ? -1 : response.getHttpStatus();
 		throw new TwilioRestException("Cannot fetch: " + method + " " + path, errorCode);
+	}
+
+
+	public  TwilioRestResponse sendSms(String fullUrl, String toPhoneNumber, String fromNumber, String body) throws TwilioRestException
+ 	{
+		 // Build the parameters
+		 Map<String, String> map = new HashMap<String,String>();
+		 map.put("To",toPhoneNumber);
+		 map.put("From", fromNumber);
+		 map.put("Body", body);
+
+		 return safePOSTWithException(fullUrl, map);
+
+	}
+
+	/**
+	 * Any errors will be embedded in the response.
+	 * @param path
+	 * @return
+	 */
+	TwilioRestResponse safePOSTWithException(final String path, final Map<String, String> vars) throws TwilioRestException
+	{
+		List<NameValuePair> paramList = generateParameters(vars);
+		TwilioRestResponse response = null;
+		for (int retry = 0; retry < numRetries; retry++) {
+            response = request(path, "POST", paramList);
+            if (response.isClientError()) {
+                response.buildAndThrowTwilioRestException();
+            }
+
+            if (response.isServerError()) {
+				try {
+					Thread.sleep(100 * retry); // Backoff on our sleep
+				}
+                catch (final InterruptedException e) {
+				}
+				continue;
+			}
+
+			return response;
+		}
+
+		int errorCode = response == null ? -1 : response.getHttpStatus();
+		throw new TwilioRestException("Cannot fetch: POST " + path, errorCode);
 	}
 
 	/**
@@ -535,7 +580,7 @@ public abstract class TwilioClient {
 		for (int retry = 0; retry < numRetries; retry++) {
 			response = request(fullUri, "GET", (Map) null);
 			if (response.isClientError()) {
-				throw TwilioRestException.parseResponse(response);
+				response.buildAndThrowTwilioRestException();
 			} else if (response.isServerError()) {
 				try {
 					Thread.sleep(100 * retry); // Backoff on our sleep

--- a/src/main/java/com/twilio/sdk/TwilioClient.java
+++ b/src/main/java/com/twilio/sdk/TwilioClient.java
@@ -1,5 +1,6 @@
 package com.twilio.sdk;
 
+import com.twilio.sdk.pojo.SMSCriteria;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -461,22 +462,17 @@ public abstract class TwilioClient {
 		throw new TwilioRestException("Cannot fetch: " + method + " " + path, errorCode);
 	}
 
-	public  TwilioRestResponse sendSms(String fullUrl, String toPhoneNumber, String fromNumber, String body) throws TwilioRestException
-	{
-		return sendSms( fullUrl,  toPhoneNumber,  fromNumber,  body, null);
-	}
-
-	public  TwilioRestResponse sendSms(String fullUrl, String toPhoneNumber, String fromNumber, String body, String callbackUrl) throws TwilioRestException
+	public  TwilioRestResponse sendSms(SMSCriteria smsCriteria) throws TwilioRestException
  	{
 		 // Build the parameters
 		 Map<String, String> map = new HashMap<String,String>();
-		 map.put("To",toPhoneNumber);
-		 map.put("From", fromNumber);
-		 map.put("Body", body);
-		 if(callbackUrl !=null)
-		 	map.put("StatusCallback",callbackUrl);
+		 map.put("To", smsCriteria.toPhoneNumber);
+		 map.put("From", smsCriteria.fromNumber);
+		 map.put("Body", smsCriteria.body);
+		 if(smsCriteria.callbackUrl !=null)
+		 	map.put("StatusCallback", smsCriteria.callbackUrl);
 
-		 return safePOSTWithException(fullUrl, map);
+		 return safePOSTWithException(smsCriteria.fullUrl, map);
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/TwilioMonitorClient.java
+++ b/src/main/java/com/twilio/sdk/TwilioMonitorClient.java
@@ -12,12 +12,13 @@ public class TwilioMonitorClient extends TwilioClient {
 
 	public static final String DEFAULT_VERSION = "v1";
 
-	public TwilioMonitorClient(final String accountSid, final String authToken) {
-		super(accountSid, authToken, "https://monitor.twilio.com");
+	@Override
+	public String getEndpoint(){
+		return "https://monitor.twilio.com";
 	}
 
-	public TwilioMonitorClient(final String accountSid, final String authToken, final String endpoint) {
-		super(accountSid, authToken, endpoint);
+	public TwilioMonitorClient(final String accountSid, final String authToken) {
+		super(accountSid, authToken);
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/TwilioPricingClient.java
+++ b/src/main/java/com/twilio/sdk/TwilioPricingClient.java
@@ -18,6 +18,10 @@ public class TwilioPricingClient extends TwilioClient {
 
     public static final String DEFAULT_VERSION = "v1";
 
+    @Override
+   	public String getEndpoint(){
+   		return "https://pricing.twilio.com";
+   	}
     /**
      * Construct a new TwilioPricingClient.
      *
@@ -28,7 +32,7 @@ public class TwilioPricingClient extends TwilioClient {
      * @param authToken Your Twilio Account's authorization token
      */
     public TwilioPricingClient(final String accountSid, final String authToken) {
-        super(accountSid, authToken, "https://pricing.twilio.com");
+        super(accountSid, authToken);
     }
 
     /**
@@ -41,9 +45,9 @@ public class TwilioPricingClient extends TwilioClient {
      * @param authToken Your Twilio Account's authorization token
      * @param endpoint Custom Twilio pricing endpoint
      */
-    public TwilioPricingClient(final String accountSid, final String authToken, String endpoint) {
-        super(accountSid, authToken, endpoint);
-    }
+//    public TwilioPricingClient(final String accountSid, final String authToken, String endpoint) {
+//        super(accountSid, authToken, endpoint);
+//    }
 
     /**
      * Get a list of objects representing countries where Twilio Voice

--- a/src/main/java/com/twilio/sdk/TwilioRestClient.java
+++ b/src/main/java/com/twilio/sdk/TwilioRestClient.java
@@ -16,19 +16,15 @@ public class TwilioRestClient extends TwilioClient {
 
 	private static final String API_URL = "https://api.twilio.com";
 
+	@Override
+	public String getEndpoint(){
+		return API_URL;
+	}
 	/** The auth account. */
 	private final Account authAccount;
 
 	public TwilioRestClient(final String accountSid, final String authToken) {
-		super(accountSid, authToken,API_URL);
-
-		authAccount = new Account(this);
-		authAccount.setSid(accountSid);
-		authAccount.setAuthToken(authToken);
-	}
-
-	public TwilioRestClient(final String accountSid, final String authToken, String endpoint) {
-		super(accountSid, authToken, endpoint);
+		super(accountSid, authToken);
 
 		authAccount = new Account(this);
 		authAccount.setSid(accountSid);

--- a/src/main/java/com/twilio/sdk/TwilioRestClient.java
+++ b/src/main/java/com/twilio/sdk/TwilioRestClient.java
@@ -1,22 +1,26 @@
 package com.twilio.sdk;
 
-import com.twilio.sdk.resource.factory.AccountFactory;
+import com.twilio.sdk.resource.factory.MessageFactory;
 import com.twilio.sdk.resource.instance.Account;
+import com.twilio.sdk.resource.instance.Message;
 import com.twilio.sdk.resource.list.AccountList;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * The client class that access http://api.twilio.com.
  */
 public class TwilioRestClient extends TwilioClient {
 
+	private static final String API_URL = "https://api.twilio.com";
+
 	/** The auth account. */
 	private final Account authAccount;
 
 	public TwilioRestClient(final String accountSid, final String authToken) {
-		super(accountSid, authToken, "https://api.twilio.com");
+		super(accountSid, authToken,API_URL);
 
 		authAccount = new Account(this);
 		authAccount.setSid(accountSid);
@@ -57,14 +61,6 @@ public class TwilioRestClient extends TwilioClient {
 		return getAccounts(new HashMap<String, String>());
 	}
 
-	/**
-	 * Return an account factory to create new subaccounts
-	 *
-	 * @return the list of accounts
-	 */
-	public AccountFactory getAccountFactory() {
-		return getAccounts();
-	}
 
 	/**
 	 * A shortcut for the most common case, returning the Account object for this authenticated client.
@@ -75,17 +71,17 @@ public class TwilioRestClient extends TwilioClient {
 		return authAccount;
 	}
 
-	/**
-	 * Get an account by account sid.
-	 *
-	 * @param sid The sid of the account you want to fetch.
-	 * @return the account
-	 */
-	public Account getAccount(final String sid) {
-		Account account = new Account(this);
-		account.setSid(sid);
-		account.setRequestAccountSid(sid);
+	public String execute(Map<String, String> map) throws TwilioRestException
+	{
+		List<NameValuePair> params = new ArrayList<NameValuePair>(map.keySet().size());
 
-		return account;
+		Set<String> keys = map.keySet();
+		for(String key : keys){
+			params.add(new BasicNameValuePair(key,map.get(key)));
+		}
+
+		MessageFactory messageFactory = getAccount().getMessageFactory();
+		Message message = messageFactory.create(params);
+		return message.getSid();
 	}
 }

--- a/src/main/java/com/twilio/sdk/TwilioRestException.java
+++ b/src/main/java/com/twilio/sdk/TwilioRestException.java
@@ -1,9 +1,5 @@
 package com.twilio.sdk;
 
-import java.util.Map;
-
-
-
 /**
  * See: <a href="https://www.twilio.com/docs/errors/">https://www.twilio.com/docs/errors/</a> for more info
  * @author FrankStratton
@@ -46,32 +42,6 @@ public class TwilioRestException extends Exception {
 		this.message = message;
 		this.errorCode = errorCode;
 		this.moreInfo = moreInfo;
-	}
-
-	/**
-	 * Parses the response.
-	 *
-	 * @param response the response
-	 * @return the twilio rest exception
-	 */
-	public static TwilioRestException parseResponse(TwilioRestResponse response) {
-		Map<String, Object> data = response.toMap();
-		String message = "";
-		String moreInfo = "";
-		int errorCode = 0;
-		if (response.isJson()) {
-			message = (String) data.get("message");
-			
-			if (data.get("code") != null) {
-				errorCode = (Integer) data.get("code");
-			}
-			if (data.get("more_info") != null) {
-				moreInfo = (String) data.get("more_info");
-			}
-		}
-		// TODO xml
-
-		return new TwilioRestException(message, errorCode, moreInfo);
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/TwilioRestResponse.java
+++ b/src/main/java/com/twilio/sdk/TwilioRestResponse.java
@@ -55,7 +55,7 @@ public class TwilioRestResponse {
 	private boolean error;
 
 	/** The content type. */
-	private String contentType;
+	private String contentType = "application/json";
 
 
 	/**

--- a/src/main/java/com/twilio/sdk/TwilioRestResponse.java
+++ b/src/main/java/com/twilio/sdk/TwilioRestResponse.java
@@ -51,14 +51,12 @@ public class TwilioRestResponse {
 	/** The url. */
 	private String url;
 
-	/** The query string. */
-	private String queryString;
-
 	/** The error. */
 	private boolean error;
 
 	/** The content type. */
 	private String contentType;
+
 
 	/**
 	 * Instantiates a new twilio rest response.
@@ -72,7 +70,7 @@ public class TwilioRestResponse {
 		Matcher m = p.matcher(url);
 		m.matches();
 		this.url = m.group(1);
-		queryString = m.group(2);
+//		queryString = m.group(2);
 		responseText = text;
 		httpStatus = status;
 		error = (status >= 400);
@@ -88,14 +86,6 @@ public class TwilioRestResponse {
 		return responseText;
 	}
 
-	/**
-	 * Sets the response text.
-	 *
-	 * @param responseText the new response text
-	 */
-	public void setResponseText(final String responseText) {
-		this.responseText = responseText;
-	}
 
 	/**
 
@@ -105,15 +95,6 @@ public class TwilioRestResponse {
 	 */
 	public int getHttpStatus() {
 		return httpStatus;
-	}
-
-	/**
-	 * Sets the http status.
-	 *
-	 * @param httpStatus the new http status
-	 */
-	public void setHttpStatus(final int httpStatus) {
-		this.httpStatus = httpStatus;
 	}
 
 	/**
@@ -134,22 +115,6 @@ public class TwilioRestResponse {
 		this.url = url;
 	}
 
-	/**
-	 * Get the query string that resulted in this response
-	 *
-	 */
-	public String getQueryString() {
-		return queryString;
-	}
-
-	/**
-	 * Sets the query string.
-	 *
-	 * @param queryString the new query string
-	 */
-	public void setQueryString(final String queryString) {
-		this.queryString = queryString;
-	}
 
 	/**
 	 * Determine if this request resulted in any kind of error
@@ -243,6 +208,34 @@ public class TwilioRestResponse {
 	public Map<String, Object> toMap() {
 		ResponseParser parser = getParser();
 		return parser.parse(this);
+	}
+
+	public void buildAndThrowTwilioRestException () throws TwilioRestException {
+		Map<String, Object> data = toMap();
+		String message = "";
+		String moreInfo = "";
+		int errorCode = 0;
+		if (isJson()) {
+			message = (String) data.get("message");
+
+			if (data.get("code") != null) {
+				errorCode = (Integer) data.get("code");
+			}
+			if (data.get("more_info") != null) {
+				moreInfo = (String) data.get("more_info");
+			}
+		}
+		else
+		{
+			//its xml
+			Map<String,Object> errorMap = (Map)data.get("RestException");
+			errorCode = Integer.valueOf((String)errorMap.get("Code"));
+			moreInfo = (String)errorMap.get("MoreInfo");
+			message = (String)errorMap.get("Message");
+		}
+
+
+		throw new TwilioRestException(message, errorCode, moreInfo);
 	}
 
 }

--- a/src/main/java/com/twilio/sdk/TwilioTaskRouterClient.java
+++ b/src/main/java/com/twilio/sdk/TwilioTaskRouterClient.java
@@ -39,13 +39,15 @@ public class TwilioTaskRouterClient extends TwilioClient {
 
 	public static final String DEFAULT_VERSION = "v1";
 
+	@Override
+	public String getEndpoint(){
+		return "https://taskrouter.twilio.com";
+	}
+
 	public TwilioTaskRouterClient(final String accountSid, final String authToken) {
-		super(accountSid, authToken, "https://taskrouter.twilio.com");
+		super(accountSid, authToken);
 	}
-	
-	public TwilioTaskRouterClient(final String accountSid, final String authToken, final String endpoint) {
-		super(accountSid, authToken, endpoint);
-	}
+
 
 	/**
 	 * Create an {@link com.twilio.sdk.resource.instance.taskrouter.Activity}.

--- a/src/main/java/com/twilio/sdk/TwilioUnreachableUrlException.java
+++ b/src/main/java/com/twilio/sdk/TwilioUnreachableUrlException.java
@@ -1,0 +1,24 @@
+package com.twilio.sdk;
+
+/**
+ * See: <a href="https://www.twilio.com/docs/errors/">https://www.twilio.com/docs/errors/</a> for more info
+ * @author FrankStratton
+ *
+ */
+public class TwilioUnreachableUrlException extends TwilioRestException {
+
+	/** The Constant serialVersionUID. */
+	private static final long serialVersionUID = -181355409302925781L;
+
+	/**
+	 * Instantiates a new twilio rest exception.
+	 *
+	 * @param message the message
+	 * @param errorCode the error code
+	 */
+	public TwilioUnreachableUrlException(String message, int errorCode) {
+		super(message, errorCode, "");
+	}
+
+
+}

--- a/src/main/java/com/twilio/sdk/examples/MessageField.java
+++ b/src/main/java/com/twilio/sdk/examples/MessageField.java
@@ -1,0 +1,15 @@
+package com.twilio.sdk.examples;
+
+/**
+ * Author: wge
+ * Date: 26/07/2015
+ * Time: 21:20
+ */
+public class MessageField
+{
+    public static final String MEDIA_URL = "MediaUrl";
+    public static final String FROM = "From";
+    public static final String BODY = "Body";
+
+    public static final String TO = "To" ;
+}

--- a/src/main/java/com/twilio/sdk/pojo/SMSCriteria.java
+++ b/src/main/java/com/twilio/sdk/pojo/SMSCriteria.java
@@ -1,0 +1,27 @@
+package com.twilio.sdk.pojo;
+
+public class SMSCriteria {
+    public final String fullUrl;
+    public final String toPhoneNumber;
+    public final String fromNumber;
+    public final String body;
+    public String callbackUrl;//not mandatory
+
+    public SMSCriteria(String fullUrl, String toPhoneNumber, String fromNumber, String body) {
+        this.fullUrl = fullUrl;
+        this.toPhoneNumber = toPhoneNumber;
+        this.fromNumber = fromNumber;
+        this.body = body;
+
+    }
+
+    public SMSCriteria(String fullUrl, String toPhoneNumber, String fromNumber, String body, String callbackUrl) {
+        this.fullUrl = fullUrl;
+        this.toPhoneNumber = toPhoneNumber;
+        this.fromNumber = fromNumber;
+        this.body = body;
+        this.callbackUrl = callbackUrl;
+    }
+
+
+}

--- a/src/main/java/com/twilio/sdk/resource/factory/MessageFactory.java
+++ b/src/main/java/com/twilio/sdk/resource/factory/MessageFactory.java
@@ -19,5 +19,5 @@ public interface MessageFactory {
 	 * @return the message
 	 * @throws TwilioRestException
    */
-	public Message create(List<NameValuePair> params) throws TwilioRestException;
+	Message create(List<NameValuePair> params) throws TwilioRestException;
 }

--- a/src/test/java/com/twilio/sdk/TwilioMockRestSmsTest.java
+++ b/src/test/java/com/twilio/sdk/TwilioMockRestSmsTest.java
@@ -1,5 +1,6 @@
 package com.twilio.sdk;
 
+import com.twilio.sdk.pojo.SMSCriteria;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +46,10 @@ public class TwilioMockRestSmsTest
         try
         {
             doThrow(expectedException).when(mockclient).safePOSTWithException(Mockito.eq(TEST_SMS_URL), Mockito.anyMap());
-            mockclient.sendSms(TEST_SMS_URL, "+15005550001", VALID_FROM_NUMBER, "test");
+
+            SMSCriteria criteria = new SMSCriteria(TEST_SMS_URL,"+15005550001",VALID_FROM_NUMBER,"test");
+
+            mockclient.sendSms(criteria);
             assertFalse(true);
         }
         catch (TwilioRestException e)
@@ -62,7 +66,10 @@ public class TwilioMockRestSmsTest
         try
         {
             doThrow(expectedException).when(mockclient).safePOSTWithException(Mockito.eq(TEST_SMS_URL), Mockito.anyMap());
-            mockclient.sendSms(TEST_SMS_URL, "+15005550001", VALID_FROM_NUMBER, "test");
+
+            SMSCriteria criteria = new SMSCriteria(TEST_SMS_URL,"+15005550001",VALID_FROM_NUMBER,"test");
+
+            mockclient.sendSms(criteria);
             assertFalse(true);
         }
         catch (TwilioRestException e)
@@ -79,7 +86,10 @@ public class TwilioMockRestSmsTest
         try
         {
             doThrow(expectedException).when(mockclient).safePOSTWithException(Mockito.eq(TEST_SMS_URL), Mockito.anyMap());
-            mockclient.sendSms(TEST_SMS_URL, "+15005550001", VALID_FROM_NUMBER, "test");
+
+            SMSCriteria criteria = new SMSCriteria(TEST_SMS_URL,"+15005550001",VALID_FROM_NUMBER,"test");
+
+            mockclient.sendSms(criteria);
             assertFalse(true);
         }
         catch (TwilioRestException e)

--- a/src/test/java/com/twilio/sdk/TwilioMockRestSmsTest.java
+++ b/src/test/java/com/twilio/sdk/TwilioMockRestSmsTest.java
@@ -1,0 +1,84 @@
+package com.twilio.sdk;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+
+/**
+ * Author: wge
+ * Date: 29/07/2015
+ * Time: 21:31
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TwilioMockRestSmsTest
+{
+    private static final String API = "https://api.twilio.com";
+    private static final String TEST_ACCOUNT_SID = "AC0649d36d4016abb849d571b713bc65b3";
+    private static final String TEST_SMS_URL = "https://api.twilio.com/2010-04-01/Accounts/" + TEST_ACCOUNT_SID + "/SMS/Messages";
+    private static final String VALID_FROM_NUMBER = "+15005550006";
+
+    @Mock
+    TwilioClient mockclient;
+
+    @Mock
+    TwilioRestResponse response;
+
+    @Before
+    public void init(){
+        MockitoAnnotations.initMocks(this);
+        mockclient = Mockito.mock(TwilioClient.class,Mockito.CALLS_REAL_METHODS);
+        response = Mockito.mock(TwilioRestResponse.class);
+    }
+
+    @Test
+    @Ignore //mockito not behaving itself
+    public void sendPinToInvalidPhone() throws TwilioUnreachableUrlException
+    {
+
+        Map<String,Object> restException = new HashMap<String, Object>();
+        restException.put("Code",21211);
+        restException.put("Message", "The 'To' number +15005550001 is not a valid phone number.");
+
+        Map<String,Object> errorMap = new HashMap();
+        errorMap.put("RestException", restException);
+
+        when(response.toMap()).thenReturn(errorMap);
+
+        try
+        {
+            Map<String, String> map = new HashMap<String,String>();
+         		 map.put("To", "+15005550001");
+         		 map.put("From", VALID_FROM_NUMBER);
+         		 map.put("Body", "test");
+
+            TwilioRestException expectedException = new TwilioRestException("The 'To' number +15005550001 is not a valid phone number.", 21211);
+
+            mockclient.setNumRetries(1);
+
+            when(mockclient.safePOSTWithException(Mockito.anyString(), Mockito.anyMap())).thenThrow(expectedException);
+//            when(mockclient.safePOSTWithException(Mockito.eq(TEST_SMS_URL), Mockito.anyMap())).thenThrow(expectedException);
+//            when(mockclient.request(Mockito.eq(TEST_SMS_URL), Mockito.eq("POST"), Mockito.anyListOf(NameValuePair.class))).thenReturn(response);
+            when(mockclient.request(Mockito.anyString(), Mockito.anyString(), Mockito.anyList())).thenReturn(response);
+            mockclient.sendSms(TEST_SMS_URL, "+15005550001", VALID_FROM_NUMBER, "test");
+            assertFalse(true);
+        }
+        catch (TwilioRestException e)
+        {
+            assertEquals(21211, e.getErrorCode());
+            assertEquals("The 'To' number +15005550001 is not a valid phone number.", e.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/com/twilio/sdk/TwilioRestSmsTest.java
+++ b/src/test/java/com/twilio/sdk/TwilioRestSmsTest.java
@@ -15,10 +15,9 @@ import static org.junit.Assert.assertFalse;
 
 public class TwilioRestSmsTest
 {
-    private static final String API = "https://api.twilio.com";
     private static final String TEST_ACCOUNT_SID = "AC0649d36d4016abb849d571b713bc65b3";
     private static final String TEST_SMS_URL = "https://api.twilio.com/2010-04-01/Accounts/" + TEST_ACCOUNT_SID + "/SMS/Messages";
-    private final TwilioClient client = new TwilioRestClient(TEST_ACCOUNT_SID, Example.AUTH_TOKEN, API);
+    private final TwilioClient client = new TwilioRestClient(TEST_ACCOUNT_SID, Example.AUTH_TOKEN);
 
     private static final String VALID_FROM_NUMBER = "+15005550006";
 
@@ -37,5 +36,13 @@ public class TwilioRestSmsTest
             assertEquals("The 'To' number +15005550001 is not a valid phone number.", e.getMessage());
         }
     }
+
+    @Test
+    public void sendPinToMyPhone() throws TwilioRestException
+    {
+         client.sendSms(TEST_SMS_URL, "+447770497729", VALID_FROM_NUMBER, "test");
+    }
+
+
 
 }

--- a/src/test/java/com/twilio/sdk/TwilioRestSmsTest.java
+++ b/src/test/java/com/twilio/sdk/TwilioRestSmsTest.java
@@ -1,0 +1,41 @@
+package com.twilio.sdk;
+
+import com.twilio.sdk.examples.Example;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Author: wge
+ * Date: 29/07/2015
+ * Time: 21:31
+ */
+
+public class TwilioRestSmsTest
+{
+    private static final String API = "https://api.twilio.com";
+    private static final String TEST_ACCOUNT_SID = "AC0649d36d4016abb849d571b713bc65b3";
+    private static final String TEST_SMS_URL = "https://api.twilio.com/2010-04-01/Accounts/" + TEST_ACCOUNT_SID + "/SMS/Messages";
+    private final TwilioClient client = new TwilioRestClient(TEST_ACCOUNT_SID, Example.AUTH_TOKEN, API);
+
+    private static final String VALID_FROM_NUMBER = "+15005550006";
+
+    @Test
+    @Ignore //runs as an integration test - takes too long for a unit test, but does work.
+    public void sendPinToInvalidPhone() throws TwilioUnreachableUrlException
+    {
+        try
+        {
+            client.sendSms(TEST_SMS_URL, "+15005550001", VALID_FROM_NUMBER, "test");
+            assertFalse(true);
+        }
+        catch (TwilioRestException e)
+        {
+            assertEquals(21211, e.getErrorCode());
+            assertEquals("The 'To' number +15005550001 is not a valid phone number.", e.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/com/twilio/sdk/TwilioRestSmsTest.java
+++ b/src/test/java/com/twilio/sdk/TwilioRestSmsTest.java
@@ -1,6 +1,7 @@
 package com.twilio.sdk;
 
 import com.twilio.sdk.examples.Example;
+import com.twilio.sdk.pojo.SMSCriteria;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -27,7 +28,8 @@ public class TwilioRestSmsTest
     {
         try
         {
-            client.sendSms(TEST_SMS_URL, "+15005550001", VALID_FROM_NUMBER, "test");
+            SMSCriteria criteria = new SMSCriteria(TEST_SMS_URL, "+15005550001", VALID_FROM_NUMBER, "test");
+            client.sendSms(criteria);
             assertFalse(true);
         }
         catch (TwilioRestException e)
@@ -40,7 +42,9 @@ public class TwilioRestSmsTest
     @Test
     public void sendPinToMyPhone() throws TwilioRestException
     {
-         client.sendSms(TEST_SMS_URL, "+447770497729", VALID_FROM_NUMBER, "test");
+        SMSCriteria criteria = new SMSCriteria(TEST_SMS_URL, "+447770497729", VALID_FROM_NUMBER, "test");
+
+        client.sendSms(criteria);
     }
 
 

--- a/src/test/java/com/twilio/sdk/examples/Example.java
+++ b/src/test/java/com/twilio/sdk/examples/Example.java
@@ -1,0 +1,37 @@
+package com.twilio.sdk.examples;
+/**
+ * Author: wge
+ * Date: 26/07/2015
+ * Time: 16:33
+ *
+ * Taken from https://www.twilio.com/docs/api/rest/sending-messages
+ * This is simpler as the client just cares about taking key/vals. The hard work is encapsulated inside the new method execute().
+ */
+
+import com.twilio.sdk.TwilioRestClient;
+import com.twilio.sdk.TwilioRestException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class Example
+{
+    // Find your Account Sid and Token at twilio.com/user/account
+    public static final String ACCOUNT_SID = "AC5ef8732a3c49700934481addd5ce1659";
+    public static final String AUTH_TOKEN = "{{ auth_token }}";
+
+    public static void main(String[] args) throws TwilioRestException
+    {
+        TwilioRestClient client = new TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN);
+
+        Map<String,String> map = new ConcurrentHashMap<String,String>();
+        map.put(MessageField.BODY, "Jenny please?! I love you <3");
+        map.put(MessageField.TO, "+15558675309");
+        map.put(MessageField.FROM, "+14158141829");
+        map.put(MessageField.MEDIA_URL, "http://www.example.com/hearts.png");
+
+        String sid =  client.execute(map);
+
+        System.out.println(sid);
+    }
+}

--- a/src/test/java/com/twilio/sdk/examples/Example.java
+++ b/src/test/java/com/twilio/sdk/examples/Example.java
@@ -18,7 +18,7 @@ public class Example
 {
     // Find your Account Sid and Token at twilio.com/user/account
     public static final String ACCOUNT_SID = "AC5ef8732a3c49700934481addd5ce1659";
-    public static final String AUTH_TOKEN = "{{ auth_token }}";
+    public static final String AUTH_TOKEN = "c9b4ebe3b5ab4089291dbf1f7fdd9607";
 
     public static void main(String[] args) throws TwilioRestException
     {


### PR DESCRIPTION
1) In general, looking through the code base, there are, in my opinion too many public methods.
To be specific, look at the existing com.twilio.sdk.examples.Example.
The messageFactory is unnecessarily exposed, when it can be encapsulated under the covers. 

As an end user, I'd like to send an sms, plug it with the strings + body. I don't care about special things happening underneath. The messageFactory is telling me this as I look at it.

So the Example is updated.

2) The TwilioRestClient now caters for xml responses (it was only json before).

I've added two tests to expose errors for consideration. The first is ignored because its an integration test - but works. The second is a mockito equivalent that I could not quite get to work - perhaps you can spot the issue.

As an aside there does not appear to be much error test coverage.