### PR TITLE
Loading Reservations under a Worker by default in TaskRouter JS SDK

### DIFF
--- a/src/main/java/com/twilio/sdk/taskrouter/TaskRouterCapability.java
+++ b/src/main/java/com/twilio/sdk/taskrouter/TaskRouterCapability.java
@@ -65,11 +65,13 @@ public class TaskRouterCapability extends CapabilityToken {
             resourceUrl = this.baseUrl + "/Workers/" + channelId;
 
             final String activityUrl = this.baseUrl + "/Activities";
-            final String reservationsUrl = this.baseUrl + "/Tasks/**";
+            final String tasksUrl = this.baseUrl + "/Tasks/**";
+            final String workerReservationsUrl = this.resourceUrl + "/Reservations/**";
 
             // add permissions to fetch the list of activities
             this.allow(activityUrl, "GET", null, null);
-            this.allow(reservationsUrl, "GET", null, null);
+            this.allow(tasksUrl, "GET", null, null);
+            this.allow(workerReservationsUrl, "GET", null, null);
         } else if (channelId.startsWith("WQ")) {
             resourceUrl = this.baseUrl + "/TaskQueues/" + channelId;
         }

--- a/src/main/java/com/twilio/sdk/taskrouter/TaskRouterWorkerCapability.java
+++ b/src/main/java/com/twilio/sdk/taskrouter/TaskRouterWorkerCapability.java
@@ -2,8 +2,9 @@ package com.twilio.sdk.taskrouter;
 
 public class TaskRouterWorkerCapability extends TaskRouterCapability {
 
-    private final String reservationsUrl;
+    private final String tasksUrl;
     private final String activityUrl;
+    private final String workerReservationsUrl;
 
     /**
      * Create a new Capability object to authorize worker clients to interact
@@ -21,13 +22,14 @@ public class TaskRouterWorkerCapability extends TaskRouterCapability {
      */
     public TaskRouterWorkerCapability(final String accountSid, final String authToken, final String workspaceSid, final String workerSid) {
         super(accountSid, authToken, workspaceSid, workerSid);
-        this.reservationsUrl = this.baseUrl + "/Tasks/**";
+        this.tasksUrl = this.baseUrl + "/Tasks/**";
         this.activityUrl = this.baseUrl + "/Activities";
+        this.workerReservationsUrl = this.resourceUrl + "/Reservations/**";
 
-        // add permissions to fetch the list of activities and list of worker
-        // reservations
+        // add permissions to fetch the list of activities, tasks and worker reservations
         this.allow(activityUrl, "GET", null, null);
-        this.allow(reservationsUrl, "GET", null, null);
+        this.allow(tasksUrl, "GET", null, null);
+        this.allow(workerReservationsUrl, "GET", null, null);
     }
 
     @Override
@@ -48,8 +50,10 @@ public class TaskRouterWorkerCapability extends TaskRouterCapability {
      * Allow a worker to update assigned reservations
      */
     public void allowReservationUpdates() {
-        final Policy policy = new Policy(this.reservationsUrl, "POST", true);
-        policies.add(policy);
+        final Policy tasksPolicy = new Policy(this.tasksUrl, "POST", true);
+        final Policy workerReservationsPolicy = new Policy(this.workerReservationsUrl, "POST", true);
+        policies.add(tasksPolicy);
+        policies.add(workerReservationsPolicy);
     }
 
 }

--- a/src/test/java/com/twilio/sdk/taskrouter/TaskRouterCapabilityTest.java
+++ b/src/test/java/com/twilio/sdk/taskrouter/TaskRouterCapabilityTest.java
@@ -32,7 +32,7 @@ public class TaskRouterCapabilityTest {
         assertEquals("v1", o.get("version"));
         assertEquals("WS456", o.get("workspace_sid"));
         final JSONArray policies = (JSONArray) o.get("policies");
-        assertEquals(7, policies.size());
+        assertEquals(8, policies.size());
         JSONObject p = (JSONObject) policies.get(0);
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", p.get("url"));
         assertEquals("GET", p.get("method"));
@@ -40,19 +40,22 @@ public class TaskRouterCapabilityTest {
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", p.get("url"));
         assertEquals("GET", p.get("method"));
         p = (JSONObject) policies.get(2);
-        assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", p.get("url"));
         assertEquals("GET", p.get("method"));
         p = (JSONObject) policies.get(3);
         assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
-        assertEquals("POST", p.get("method"));
+        assertEquals("GET", p.get("method"));
         p = (JSONObject) policies.get(4);
+        assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
+        assertEquals("POST", p.get("method"));
+        p = (JSONObject) policies.get(5);
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", p.get("url"));
         assertEquals("GET", p.get("method"));
         assertTrue((Boolean) p.get("allow"));
-        p = (JSONObject) policies.get(5);
+        p = (JSONObject) policies.get(6);
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", p.get("url"));
         assertEquals("POST", p.get("method"));
-        p = (JSONObject) policies.get(6);
+        p = (JSONObject) policies.get(7);
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", p.get("url"));
         assertEquals("POST", p.get("method"));
         final JSONObject filters = (JSONObject) p.get("post_filter");
@@ -64,46 +67,6 @@ public class TaskRouterCapabilityTest {
     @Test
     public void testGenerateDefaultWorkerToken() throws Exception {
         final TaskRouterWorkerCapability capability = new TaskRouterWorkerCapability("AC123", "foobar", "WS456", "WK789");
-        final String token = capability.generateToken();
-        final String[] parts = token.split("\\.");
-        assertEquals(3, parts.length);
-        final String payload = parts[1];
-        final byte[] bytes = Base64.decodeBase64(payload);
-        final String json = new String(bytes, "UTF-8");
-        final JSONParser parser = new JSONParser();
-        final Object decoded = parser.parse(json);
-        final JSONObject o = (JSONObject) decoded;
-        assertEquals("AC123", o.get("iss"));
-        assertEquals("AC123", o.get("account_sid"));
-        assertEquals("WK789", o.get("channel"));
-        assertEquals("WK789", o.get("friendly_name"));
-        assertEquals("v1", o.get("version"));
-        assertEquals("WS456", o.get("workspace_sid"));
-        final JSONArray policies = (JSONArray) o.get("policies");
-        assertEquals(5, policies.size());
-        JSONObject p = (JSONObject) policies.get(0);
-        assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
-        assertEquals("GET", p.get("method"));
-        p = (JSONObject) policies.get(1);
-        assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
-        assertEquals("POST", p.get("method"));
-        p = (JSONObject) policies.get(2);
-        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", p.get("url"));
-        assertEquals("GET", p.get("method"));
-        assertTrue((Boolean) p.get("allow"));
-        p = (JSONObject) policies.get(3);
-        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", p.get("url"));
-        assertEquals("GET", p.get("method"));
-        p = (JSONObject) policies.get(4);
-        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", p.get("url"));
-        assertEquals("GET", p.get("method"));
-
-    }
-
-    @Test
-    public void testGenerateWorkerTokenWithActivities() throws Exception {
-        final TaskRouterWorkerCapability capability = new TaskRouterWorkerCapability("AC123", "foobar", "WS456", "WK789");
-        capability.allowActivityUpdates();
         final String token = capability.generateToken();
         final String[] parts = token.split("\\.");
         assertEquals(3, parts.length);
@@ -138,6 +101,52 @@ public class TaskRouterCapabilityTest {
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", p.get("url"));
         assertEquals("GET", p.get("method"));
         p = (JSONObject) policies.get(5);
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", p.get("url"));
+        assertEquals("GET", p.get("method"));
+
+    }
+
+    @Test
+    public void testGenerateWorkerTokenWithActivities() throws Exception {
+        final TaskRouterWorkerCapability capability = new TaskRouterWorkerCapability("AC123", "foobar", "WS456", "WK789");
+        capability.allowActivityUpdates();
+        final String token = capability.generateToken();
+        final String[] parts = token.split("\\.");
+        assertEquals(3, parts.length);
+        final String payload = parts[1];
+        final byte[] bytes = Base64.decodeBase64(payload);
+        final String json = new String(bytes, "UTF-8");
+        final JSONParser parser = new JSONParser();
+        final Object decoded = parser.parse(json);
+        final JSONObject o = (JSONObject) decoded;
+        assertEquals("AC123", o.get("iss"));
+        assertEquals("AC123", o.get("account_sid"));
+        assertEquals("WK789", o.get("channel"));
+        assertEquals("WK789", o.get("friendly_name"));
+        assertEquals("v1", o.get("version"));
+        assertEquals("WS456", o.get("workspace_sid"));
+        final JSONArray policies = (JSONArray) o.get("policies");
+        assertEquals(7, policies.size());
+        JSONObject p = (JSONObject) policies.get(0);
+        assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
+        assertEquals("GET", p.get("method"));
+        p = (JSONObject) policies.get(1);
+        assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
+        assertEquals("POST", p.get("method"));
+        p = (JSONObject) policies.get(2);
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", p.get("url"));
+        assertEquals("GET", p.get("method"));
+        assertTrue((Boolean) p.get("allow"));
+        p = (JSONObject) policies.get(3);
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", p.get("url"));
+        assertEquals("GET", p.get("method"));
+        p = (JSONObject) policies.get(4);
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", p.get("url"));
+        assertEquals("GET", p.get("method"));
+        p = (JSONObject) policies.get(5);
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", p.get("url"));
+        assertEquals("GET", p.get("method"));
+        p = (JSONObject) policies.get(6);
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", p.get("url"));
         assertEquals("POST", p.get("method"));
 
@@ -167,7 +176,7 @@ public class TaskRouterCapabilityTest {
         assertEquals("v1", o.get("version"));
         assertEquals("WS456", o.get("workspace_sid"));
         final JSONArray policies = (JSONArray) o.get("policies");
-        assertEquals(6, policies.size());
+        assertEquals(8, policies.size());
         JSONObject p = (JSONObject) policies.get(0);
         assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
         assertEquals("GET", p.get("method"));
@@ -185,7 +194,13 @@ public class TaskRouterCapabilityTest {
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", p.get("url"));
         assertEquals("GET", p.get("method"));
         p = (JSONObject) policies.get(5);
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", p.get("url"));
+        assertEquals("GET", p.get("method"));
+        p = (JSONObject) policies.get(6);
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", p.get("url"));
+        assertEquals("POST", p.get("method"));
+        p = (JSONObject) policies.get(7);
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", p.get("url"));
         assertEquals("POST", p.get("method"));
 
         final JSONObject filters = (JSONObject) p.get("post_filter");
@@ -324,7 +339,7 @@ public class TaskRouterCapabilityTest {
         assertEquals("v1", o.get("version"));
         assertEquals("WS456", o.get("workspace_sid"));
         final JSONArray policies = (JSONArray) o.get("policies");
-        assertEquals(5, policies.size());
+        assertEquals(6, policies.size());
         JSONObject p = (JSONObject) policies.get(0);
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities", p.get("url"));
         assertEquals("GET", p.get("method"));
@@ -332,12 +347,15 @@ public class TaskRouterCapabilityTest {
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", p.get("url"));
         assertEquals("GET", p.get("method"));
         p = (JSONObject) policies.get(2);
-        assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
+        assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", p.get("url"));
         assertEquals("GET", p.get("method"));
         p = (JSONObject) policies.get(3);
         assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
-        assertEquals("POST", p.get("method"));
+        assertEquals("GET", p.get("method"));
         p = (JSONObject) policies.get(4);
+        assertEquals("https://event-bridge.twilio.com/v1/wschannels/AC123/WK789", p.get("url"));
+        assertEquals("POST", p.get("method"));
+        p = (JSONObject) policies.get(5);
         assertEquals("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", p.get("url"));
         assertEquals("GET", p.get("method"));
         assertTrue((Boolean) p.get("allow"));


### PR DESCRIPTION
- Allow fetching Reservations under a Worker by default
- Allow updating Reservations under a Worker