### PR TITLE
Adding tasks_by_priority to task queue statistics

### DIFF
--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
@@ -119,7 +119,7 @@ public class TaskQueueStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	 *
 	 * @return map of task counts by priority
 	 */
-	public Map<String, Integer> getTasksWithPriority() {
+	public Map<String, Integer> getTasksByPriority() {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
 
 		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
@@ -106,9 +106,9 @@ public class TaskQueueStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	 *
 	 * @return the number of tasks with priority p
 	 */
-	public int getTasksWithPriority(int priority) {
+	public int getTasksWithPriority(String priority) {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-		Integer tasksCount = (Integer) tasksByPriority.get(String.valueOf(priority));
+		Integer tasksCount = (Integer) tasksByPriority.get(priority);
 		return tasksCount != null ? tasksCount : 0;
 	}
 

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -101,16 +102,13 @@ public class TaskQueueStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	}
 
 	/**
-	 * Get the number of tasks with the Priority
-	 * @return number of tasks with Priority priority
+	 * Get the number of tasks for each priority
+	 *
+	 * @return the number of tasks with priority p
 	 */
-	public Integer getTasksWithPriority(int priority) {
+	public int getTasksWithPriority(int priority) {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-
-		String tasksByPriorityKey = "Priority-" + String.valueOf(priority);
-
-		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
-
+		Integer tasksCount = (Integer) tasksByPriority.get(String.valueOf(priority));
 		return tasksCount != null ? tasksCount : 0;
 	}
 
@@ -121,12 +119,10 @@ public class TaskQueueStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	 */
 	public Map<String, Integer> getTasksByPriority() {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-
 		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();
-		for (String priorityKey : tasksByPriority.keySet()) {
-			tasksByPriorityMap.put(priorityKey, (Integer) tasksByPriority.get(priorityKey));
+		for (Entry<String, Object> entry : tasksByPriority.entrySet()) {
+			tasksByPriorityMap.put(entry.getKey(), (Integer) entry.getValue());
 		}
-
 		return tasksByPriorityMap;
 	}
 

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
@@ -24,6 +24,8 @@ public class TaskQueueStatistics extends NextGenInstanceResource<TwilioTaskRoute
 
 	private static final String TASKS_BY_STATUS_PROPERTY = "tasks_by_status";
 
+	private static final String TASKS_BY_PRIORITY_PROPERTY = "tasks_by_priority";
+
 	private static final String TASK_QUEUE_SID_PROPERTY = "task_queue_sid";
 
 	private static final String WORKSPACE_SID_PROPERTY = "workspace_sid";
@@ -95,6 +97,20 @@ public class TaskQueueStatistics extends NextGenInstanceResource<TwilioTaskRoute
 		} catch (IllegalArgumentException e) {
 			return null;
 		}
+	}
+
+	/**
+	 * Get the number of tasks with the Priority
+	 * @return number of tasks with Priority priority
+	 */
+	public Integer getTasksWithPriority(int priority) {
+		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
+
+		String tasksByPriorityKey = "Priority-" + String.valueOf(priority);
+
+		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
+
+		return tasksCount != null ? tasksCount : 0;
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatistics.java
@@ -7,6 +7,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -111,6 +112,22 @@ public class TaskQueueStatistics extends NextGenInstanceResource<TwilioTaskRoute
 		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
 
 		return tasksCount != null ? tasksCount : 0;
+	}
+
+	/**
+	 * Get a map of task counts by priority
+	 *
+	 * @return map of task counts by priority
+	 */
+	public Map<String, Integer> getTasksWithPriority() {
+		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
+
+		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();
+		for (String priorityKey : tasksByPriority.keySet()) {
+			tasksByPriorityMap.put(priorityKey, (Integer) tasksByPriority.get(priorityKey));
+		}
+
+		return tasksByPriorityMap;
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
@@ -223,9 +223,9 @@ public class WorkflowStatistics extends NextGenInstanceResource<TwilioTaskRouter
 	 *
 	 * @return the number of tasks with priority p
 	 */
-	public int getTasksWithPriority(int priority) {
+	public int getTasksWithPriority(String priority) {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-		Integer tasksCount = (Integer) tasksByPriority.get(String.valueOf(priority));
+		Integer tasksCount = (Integer) tasksByPriority.get(priority);
 		return tasksCount != null ? tasksCount : 0;
 	}
 

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
@@ -4,6 +4,7 @@ import com.twilio.sdk.TwilioTaskRouterClient;
 import com.twilio.sdk.resource.NextGenInstanceResource;
 
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -227,6 +228,22 @@ public class WorkflowStatistics extends NextGenInstanceResource<TwilioTaskRouter
 		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
 
 		return tasksCount != null ? tasksCount : 0;
+	}
+
+	/**
+	 * Get a map of task counts by priority
+	 *
+	 * @return map of task counts by priority
+	 */
+	public Map<String, Integer> getTasksWithPriority() {
+		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
+
+		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();
+		for (String priorityKey : tasksByPriority.keySet()) {
+			tasksByPriorityMap.put(priorityKey, (Integer) tasksByPriority.get(priorityKey));
+		}
+
+		return tasksByPriorityMap;
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
@@ -6,6 +6,7 @@ import com.twilio.sdk.resource.NextGenInstanceResource;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -222,11 +223,9 @@ public class WorkflowStatistics extends NextGenInstanceResource<TwilioTaskRouter
 	 *
 	 * @return the number of tasks with priority p
 	 */
-	public Integer getTasksWithPriority(int priority) {
+	public int getTasksWithPriority(int priority) {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-		String tasksByPriorityKey = "Priority-" + String.valueOf(priority);
-		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
-
+		Integer tasksCount = (Integer) tasksByPriority.get(String.valueOf(priority));
 		return tasksCount != null ? tasksCount : 0;
 	}
 
@@ -237,12 +236,10 @@ public class WorkflowStatistics extends NextGenInstanceResource<TwilioTaskRouter
 	 */
 	public Map<String, Integer> getTasksByPriority() {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-
 		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();
-		for (String priorityKey : tasksByPriority.keySet()) {
-			tasksByPriorityMap.put(priorityKey, (Integer) tasksByPriority.get(priorityKey));
+		for (Entry<String, Object> entry : tasksByPriority.entrySet()) {
+			tasksByPriorityMap.put(entry.getKey(), (Integer) entry.getValue());
 		}
-
 		return tasksByPriorityMap;
 	}
 

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
@@ -20,6 +20,8 @@ public class WorkflowStatistics extends NextGenInstanceResource<TwilioTaskRouter
 
 	private static final String TASKS_BY_STATUS_PROPERTY = "tasks_by_status";
 
+	private static final String TASKS_BY_PRIORITY_PROPERTY = "tasks_by_priority";
+
 	private static final String WORKFLOW_SID_PROPERTY = "workflow_sid";
 
 	private static final String WORKSPACE_SID_PROPERTY = "workspace_sid";
@@ -212,6 +214,19 @@ public class WorkflowStatistics extends NextGenInstanceResource<TwilioTaskRouter
 	 */
 	public Integer getTotalTasks() {
 		return (Integer) getRealtime().get("total_tasks");
+	}
+
+	/**
+	 * Get the number of tasks for each priority
+	 *
+	 * @return the number of tasks with priority p
+	 */
+	public Integer getTasksWithPriority(int priority) {
+		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
+		String tasksByPriorityKey = "Priority-" + String.valueOf(priority);
+		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
+
+		return tasksCount != null ? tasksCount : 0;
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatistics.java
@@ -235,7 +235,7 @@ public class WorkflowStatistics extends NextGenInstanceResource<TwilioTaskRouter
 	 *
 	 * @return map of task counts by priority
 	 */
-	public Map<String, Integer> getTasksWithPriority() {
+	public Map<String, Integer> getTasksByPriority() {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
 
 		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -254,6 +255,22 @@ public class WorkspaceStatistics extends NextGenInstanceResource<TwilioTaskRoute
 		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
 
 		return tasksCount != null ? tasksCount : 0;
+	}
+
+	/**
+	 * Get a map of task counts by priority
+	 *
+	 * @return map of task counts by priority
+	 */
+	public Map<String, Integer> getTasksWithPriority() {
+		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
+
+		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();
+		for (String priorityKey : tasksByPriority.keySet()) {
+			tasksByPriorityMap.put(priorityKey, (Integer) tasksByPriority.get(priorityKey));
+		}
+
+		return tasksByPriorityMap;
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
@@ -25,6 +25,8 @@ public class WorkspaceStatistics extends NextGenInstanceResource<TwilioTaskRoute
 
 	private static final String TASKS_BY_STATUS_PROPERTY = "tasks_by_status";
 
+	private static final String TASKS_BY_PRIORITY_PROPERTY = "tasks_by_priority";
+
 	private static final String WORKSPACE_SID_PROPERTY = "workspace_sid";
 
 	/**
@@ -239,6 +241,19 @@ public class WorkspaceStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	 */
 	public Integer getTotalWorkers() {
 		return (Integer) getRealtime().get("total_workers");
+	}
+
+	/**
+	 * Get the number of tasks for each priority
+	 *
+	 * @return the number of tasks with priority p
+	 */
+	public Integer getTasksWithPriority(int priority) {
+		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
+		String tasksByPriorityKey = "Priority-" + String.valueOf(priority);
+		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
+
+		return tasksCount != null ? tasksCount : 0;
 	}
 
 	/**

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
@@ -262,7 +262,7 @@ public class WorkspaceStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	 *
 	 * @return map of task counts by priority
 	 */
-	public Map<String, Integer> getTasksWithPriority() {
+	public Map<String, Integer> getTasksByPriority() {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
 
 		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
@@ -250,9 +250,9 @@ public class WorkspaceStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	 *
 	 * @return the number of tasks with priority p
 	 */
-	public int getTasksWithPriority(int priority) {
+	public int getTasksWithPriority(String priority) {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-		Integer tasksCount = (Integer) tasksByPriority.get(String.valueOf(priority));
+		Integer tasksCount = (Integer) tasksByPriority.get(priority);
 		return tasksCount != null ? tasksCount : 0;
 	}
 

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
@@ -249,11 +249,9 @@ public class WorkspaceStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	 *
 	 * @return the number of tasks with priority p
 	 */
-	public Integer getTasksWithPriority(int priority) {
+	public int getTasksWithPriority(int priority) {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-		String tasksByPriorityKey = "Priority-" + String.valueOf(priority);
-		Integer tasksCount = (Integer) tasksByPriority.get(tasksByPriorityKey);
-
+		Integer tasksCount = (Integer) tasksByPriority.get(String.valueOf(priority));
 		return tasksCount != null ? tasksCount : 0;
 	}
 
@@ -264,12 +262,10 @@ public class WorkspaceStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	 */
 	public Map<String, Integer> getTasksByPriority() {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
-
 		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();
-		for (String priorityKey : tasksByPriority.keySet()) {
-			tasksByPriorityMap.put(priorityKey, (Integer) tasksByPriority.get(priorityKey));
+		for (Map.Entry<String, Object> entry : tasksByPriority.entrySet()) {
+			tasksByPriorityMap.put(entry.getKey(), (Integer) entry.getValue());
 		}
-
 		return tasksByPriorityMap;
 	}
 

--- a/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
+++ b/src/main/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatistics.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.HashMap;
 import java.util.Set;
 
@@ -263,7 +264,7 @@ public class WorkspaceStatistics extends NextGenInstanceResource<TwilioTaskRoute
 	public Map<String, Integer> getTasksByPriority() {
 		Map<String, Object> tasksByPriority = (Map<String, Object>) getRealtime().get(TASKS_BY_PRIORITY_PROPERTY);
 		Map<String, Integer> tasksByPriorityMap = new HashMap<String, Integer>();
-		for (Map.Entry<String, Object> entry : tasksByPriority.entrySet()) {
+		for (Entry<String, Object> entry : tasksByPriority.entrySet()) {
 			tasksByPriorityMap.put(entry.getKey(), (Integer) entry.getValue());
 		}
 		return tasksByPriorityMap;

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
@@ -43,6 +43,8 @@ public class TaskQueueStatisticsTest extends BasicRequestTester {
 		assertTrue(taskQueueStatistics.getTotalEligibleWorkers() == 3);
 		assertTrue(taskQueueStatistics.getTotalTasks() == 1);
 		assertTrue(taskQueueStatistics.getTasksWithPriority(5) == 1);
+		assertTrue(taskQueueStatistics.getTasksWithPriority().size() == 1);
+		assertTrue(taskQueueStatistics.getTasksWithPriority().get("Priority-5") == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
@@ -42,6 +42,7 @@ public class TaskQueueStatisticsTest extends BasicRequestTester {
 		assertTrue(taskQueueStatistics.getTotalAvailableWorkers() == 0);
 		assertTrue(taskQueueStatistics.getTotalEligibleWorkers() == 3);
 		assertTrue(taskQueueStatistics.getTotalTasks() == 1);
+		assertTrue(taskQueueStatistics.getTasksWithPriority(5) == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
@@ -42,7 +42,7 @@ public class TaskQueueStatisticsTest extends BasicRequestTester {
 		assertTrue(taskQueueStatistics.getTotalAvailableWorkers() == 0);
 		assertTrue(taskQueueStatistics.getTotalEligibleWorkers() == 3);
 		assertTrue(taskQueueStatistics.getTotalTasks() == 1);
-		assertTrue(taskQueueStatistics.getTasksWithPriority(5) == 1);
+		assertTrue(taskQueueStatistics.getTasksWithPriority("5") == 1);
 		assertTrue(taskQueueStatistics.getTasksByPriority().size() == 1);
 		assertTrue(taskQueueStatistics.getTasksByPriority().get("5") == 1);
 	}

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
@@ -43,8 +43,8 @@ public class TaskQueueStatisticsTest extends BasicRequestTester {
 		assertTrue(taskQueueStatistics.getTotalEligibleWorkers() == 3);
 		assertTrue(taskQueueStatistics.getTotalTasks() == 1);
 		assertTrue(taskQueueStatistics.getTasksWithPriority(5) == 1);
-		assertTrue(taskQueueStatistics.getTasksWithPriority().size() == 1);
-		assertTrue(taskQueueStatistics.getTasksWithPriority().get("Priority-5") == 1);
+		assertTrue(taskQueueStatistics.getTasksByPriority().size() == 1);
+		assertTrue(taskQueueStatistics.getTasksByPriority().get("Priority-5") == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/TaskQueueStatisticsTest.java
@@ -44,7 +44,7 @@ public class TaskQueueStatisticsTest extends BasicRequestTester {
 		assertTrue(taskQueueStatistics.getTotalTasks() == 1);
 		assertTrue(taskQueueStatistics.getTasksWithPriority(5) == 1);
 		assertTrue(taskQueueStatistics.getTasksByPriority().size() == 1);
-		assertTrue(taskQueueStatistics.getTasksByPriority().get("Priority-5") == 1);
+		assertTrue(taskQueueStatistics.getTasksByPriority().get("5") == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
@@ -39,6 +39,7 @@ public class WorkflowStatisticsTest extends BasicRequestTester {
 		assertTrue(workflowStatistics.getTasksMoved() == 0);
 		assertTrue(workflowStatistics.getTasksTimedOutInWorkflow() == 0);
 		assertTrue(workflowStatistics.getTotalTasks() == 1);
+		assertTrue(workflowStatistics.getTasksWithPriority(5) == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
@@ -40,8 +40,8 @@ public class WorkflowStatisticsTest extends BasicRequestTester {
 		assertTrue(workflowStatistics.getTasksTimedOutInWorkflow() == 0);
 		assertTrue(workflowStatistics.getTotalTasks() == 1);
 		assertTrue(workflowStatistics.getTasksWithPriority(5) == 1);
-		assertTrue(workflowStatistics.getTasksWithPriority().size() == 1);
-		assertTrue(workflowStatistics.getTasksWithPriority().get("Priority-5") == 1);
+		assertTrue(workflowStatistics.getTasksByPriority().size() == 1);
+		assertTrue(workflowStatistics.getTasksByPriority().get("Priority-5") == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
@@ -41,7 +41,7 @@ public class WorkflowStatisticsTest extends BasicRequestTester {
 		assertTrue(workflowStatistics.getTotalTasks() == 1);
 		assertTrue(workflowStatistics.getTasksWithPriority(5) == 1);
 		assertTrue(workflowStatistics.getTasksByPriority().size() == 1);
-		assertTrue(workflowStatistics.getTasksByPriority().get("Priority-5") == 1);
+		assertTrue(workflowStatistics.getTasksByPriority().get("5") == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
@@ -40,6 +40,8 @@ public class WorkflowStatisticsTest extends BasicRequestTester {
 		assertTrue(workflowStatistics.getTasksTimedOutInWorkflow() == 0);
 		assertTrue(workflowStatistics.getTotalTasks() == 1);
 		assertTrue(workflowStatistics.getTasksWithPriority(5) == 1);
+		assertTrue(workflowStatistics.getTasksWithPriority().size() == 1);
+		assertTrue(workflowStatistics.getTasksWithPriority().get("Priority-5") == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkflowStatisticsTest.java
@@ -39,7 +39,7 @@ public class WorkflowStatisticsTest extends BasicRequestTester {
 		assertTrue(workflowStatistics.getTasksMoved() == 0);
 		assertTrue(workflowStatistics.getTasksTimedOutInWorkflow() == 0);
 		assertTrue(workflowStatistics.getTotalTasks() == 1);
-		assertTrue(workflowStatistics.getTasksWithPriority(5) == 1);
+		assertTrue(workflowStatistics.getTasksWithPriority("5") == 1);
 		assertTrue(workflowStatistics.getTasksByPriority().size() == 1);
 		assertTrue(workflowStatistics.getTasksByPriority().get("5") == 1);
 	}

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
@@ -43,6 +43,7 @@ public class WorkspaceStatisticsTest extends BasicRequestTester {
 		assertTrue(workspaceStatistics.getTasksTimedOutInWorkflow() == 0);
 		assertTrue(workspaceStatistics.getTotalTasks() == 1);
 		assertTrue(workspaceStatistics.getTotalWorkers() == 3);
+		assertTrue(workspaceStatistics.getTasksWithPriority(5) == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
@@ -44,8 +44,8 @@ public class WorkspaceStatisticsTest extends BasicRequestTester {
 		assertTrue(workspaceStatistics.getTotalTasks() == 1);
 		assertTrue(workspaceStatistics.getTotalWorkers() == 3);
 		assertTrue(workspaceStatistics.getTasksWithPriority(5) == 1);
-		assertTrue(workspaceStatistics.getTasksWithPriority().size() == 1);
-		assertTrue(workspaceStatistics.getTasksWithPriority().get("Priority-5") == 1);
+		assertTrue(workspaceStatistics.getTasksByPriority().size() == 1);
+		assertTrue(workspaceStatistics.getTasksByPriority().get("Priority-5") == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
@@ -43,7 +43,7 @@ public class WorkspaceStatisticsTest extends BasicRequestTester {
 		assertTrue(workspaceStatistics.getTasksTimedOutInWorkflow() == 0);
 		assertTrue(workspaceStatistics.getTotalTasks() == 1);
 		assertTrue(workspaceStatistics.getTotalWorkers() == 3);
-		assertTrue(workspaceStatistics.getTasksWithPriority(5) == 1);
+		assertTrue(workspaceStatistics.getTasksWithPriority("5") == 1);
 		assertTrue(workspaceStatistics.getTasksByPriority().size() == 1);
 		assertTrue(workspaceStatistics.getTasksByPriority().get("5") == 1);
 	}

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
@@ -45,7 +45,7 @@ public class WorkspaceStatisticsTest extends BasicRequestTester {
 		assertTrue(workspaceStatistics.getTotalWorkers() == 3);
 		assertTrue(workspaceStatistics.getTasksWithPriority(5) == 1);
 		assertTrue(workspaceStatistics.getTasksByPriority().size() == 1);
-		assertTrue(workspaceStatistics.getTasksByPriority().get("Priority-5") == 1);
+		assertTrue(workspaceStatistics.getTasksByPriority().get("5") == 1);
 	}
 
 }

--- a/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
+++ b/src/test/java/com/twilio/sdk/resource/instance/taskrouter/WorkspaceStatisticsTest.java
@@ -44,6 +44,8 @@ public class WorkspaceStatisticsTest extends BasicRequestTester {
 		assertTrue(workspaceStatistics.getTotalTasks() == 1);
 		assertTrue(workspaceStatistics.getTotalWorkers() == 3);
 		assertTrue(workspaceStatistics.getTasksWithPriority(5) == 1);
+		assertTrue(workspaceStatistics.getTasksWithPriority().size() == 1);
+		assertTrue(workspaceStatistics.getTasksWithPriority().get("Priority-5") == 1);
 	}
 
 }

--- a/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/task_queue_statistics.json
+++ b/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/task_queue_statistics.json
@@ -21,6 +21,9 @@
             "assigned": 1,
             "reserved": 0
         },
+        "tasks_by_priority": {
+            "Priority-5": 1
+        },
         "activity_statistics": [
             {
                 "sid": "WA36da5e4272ecadef27920fa475617394",

--- a/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/task_queue_statistics.json
+++ b/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/task_queue_statistics.json
@@ -22,7 +22,7 @@
             "reserved": 0
         },
         "tasks_by_priority": {
-            "Priority-5": 1
+            "5": 1
         },
         "activity_statistics": [
             {

--- a/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/workflow_statistics.json
+++ b/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/workflow_statistics.json
@@ -7,6 +7,9 @@
             "pending": 0,
             "assigned": 1,
             "reserved": 0
+        },
+        "tasks_by_priority": {
+            "Priority-5":1
         }
     },
     "account_sid": "ACe0228445f532b79547997ce0a552cc7a",

--- a/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/workflow_statistics.json
+++ b/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/workflow_statistics.json
@@ -9,7 +9,7 @@
             "reserved": 0
         },
         "tasks_by_priority": {
-            "Priority-5":1
+            "5":1
         }
     },
     "account_sid": "ACe0228445f532b79547997ce0a552cc7a",

--- a/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/workspace_statistics.json
+++ b/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/workspace_statistics.json
@@ -21,6 +21,9 @@
             "assigned": 1,
             "reserved": 0
         },
+        "tasks_by_priority": {
+            "Priority-5":1
+        },
         "activity_statistics": [
             {
                 "sid": "WA36da5e4272ecadef27920fa475617394",

--- a/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/workspace_statistics.json
+++ b/src/test/resources/com/twilio/sdk/resource/instance/taskrouter/workspace_statistics.json
@@ -22,7 +22,7 @@
             "reserved": 0
         },
         "tasks_by_priority": {
-            "Priority-5":1
+            "5":1
         },
         "activity_statistics": [
             {

--- a/src/test/resources/com/twilio/sdk/resource/list/taskrouter/task_queues_statistics.json
+++ b/src/test/resources/com/twilio/sdk/resource/list/taskrouter/task_queues_statistics.json
@@ -33,6 +33,7 @@
                     "assigned": 0,
                     "reserved": 0
                 },
+                "tasks_by_priority": {},
                 "activity_statistics": [
                     {
                         "sid": "WA79bcc984ca4fe04a31f2f91807a53ca0",


### PR DESCRIPTION
GET request to TaskQueue, Workflow and Workspace Statistics will have a field "tasks_by_priority" under RealTime Stats, similar to the "tasks_by_status" field. 

Example: 
"tasks_by_priority": {"5":1}