### PR TITLE
Fix NPE vulnerability in ApiException getCode/getStatusCode

### DIFF
--- a/src/main/java/com/twilio/exception/ApiException.java
+++ b/src/main/java/com/twilio/exception/ApiException.java
@@ -44,7 +44,7 @@ public class ApiException extends TwilioException {
         this.status = status;
     }
 
-    public int getCode() {
+    public Integer getCode() {
         return code;
     }
 
@@ -52,7 +52,7 @@ public class ApiException extends TwilioException {
         return moreInfo;
     }
 
-    public int getStatusCode() {
+    public Integer getStatusCode() {
         return status;
     }
 }

--- a/src/test/java/com/twilio/exception/ApiExceptionTest.java
+++ b/src/test/java/com/twilio/exception/ApiExceptionTest.java
@@ -1,0 +1,53 @@
+package com.twilio.exception;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+@SuppressWarnings("ThrowableInstanceNeverThrown")
+public class ApiExceptionTest {
+
+    private final String anyMessage = "message for test";
+    private final Throwable anyCause = new RuntimeException("some root cause");
+    private final String anyMoreInfo = "more info";
+    private final int anyErrorCode = 123;
+    private final int anyHttpStatus = 200;
+
+
+    @Test
+    public void singleArgConstructorShouldPreserveMessage() {
+        ApiException error = new ApiException(anyMessage);
+        assertEquals(anyMessage, error.getMessage());
+    }
+
+    @Test
+    public void twoArgConstructorShouldPreserveMessageAndCause() {
+        ApiException error = new ApiException(anyMessage, anyCause);
+        assertEquals("Message", anyMessage, error.getMessage());
+        assertSame("Cause", anyCause, error.getCause());
+    }
+
+    @Test
+    public void fullConstructorShouldPreserveAllValues() {
+        ApiException error = new ApiException(anyMessage, anyErrorCode, anyMoreInfo, anyHttpStatus, anyCause);
+        assertEquals("Message", anyMessage, error.getMessage());
+        assertSame("Cause", anyCause, error.getCause());
+        assertEquals("More info", anyMoreInfo, error.getMoreInfo());
+        assertEquals("Error code", anyErrorCode, error.getCode().intValue());
+        assertEquals("Status code", anyHttpStatus, error.getStatusCode().intValue());
+    }
+
+    @Test
+    public void getCodeShouldNotThrowExceptionWhenCodeIsNull() {
+        ApiException error = new ApiException(anyMessage);
+        assertEquals(null, error.getCode());
+    }
+
+    @Test
+    public void getStatusCodeShouldNotThrowExceptionWhenCodeIsNull() {
+        ApiException error = new ApiException(anyMessage);
+        assertEquals(null, error.getStatusCode());
+    }
+
+}


### PR DESCRIPTION
The `ApiException` class allows you to pass `null` for `status` and `code` parameters.  These are stored inside the class as `java.lang.Integer`, which is fine since that is nullable.

But when you ask the exception for its code or status, those getters return primitive `int`, which throws a `NullPointerException` if the underlying value is null.  For example, this throws a NPE:

```java
ApiException e = new ApiException(“danger”);
e.getCode();
```

There are three constructors, and two of them explicitly pass `null` for these fields, which means you can safely construct an `ApiException` that will bomb later when someone innocently asks for its status or code.

This PR changes the result types on `getCode()` and `getStatusCode()` from primitive `int` to `java.lang.Integer`.

There is another exception in the same package called `RestException` that also has these two fields, but it has safe getters which return nullable values instead of primitive `int`, so this pattern has already been applied elsewhere in the SDK.

