### PR TITLE
Update NetworkHttpClient.java

### DIFF
--- a/src/main/java/com/twilio/http/NetworkHttpClient.java
+++ b/src/main/java/com/twilio/http/NetworkHttpClient.java
@@ -43,6 +43,7 @@ public class NetworkHttpClient extends HttpClient {
         );
 
         client = HttpClientBuilder.create()
+            .useSystemProperties()
             .setConnectionManager(new PoolingHttpClientConnectionManager())
             .setDefaultRequestConfig(config)
             .setDefaultHeaders(headers)


### PR DESCRIPTION
To use JVM properties we need to add useSystemProperties() call, for example to use proxy settings.