### PR TITLE
Ability to add undocumented options to requests

### DIFF
--- a/src/main/java/com/twilio/twiml/Conference.java
+++ b/src/main/java/com/twilio/twiml/Conference.java
@@ -235,7 +235,7 @@ public class Conference extends TwiML {
     }
 
     public Map<String, String> getOptions() {
-        Map<String, String> convertedMap = new HashMap();
+        Map<String, String> convertedMap = new HashMap<>();
 
         Set<QName> keys = options.keySet();
         for (QName key : keys) {

--- a/src/main/java/com/twilio/twiml/Conference.java
+++ b/src/main/java/com/twilio/twiml/Conference.java
@@ -3,12 +3,18 @@ package com.twilio.twiml;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
+import javax.xml.bind.annotation.XmlAnyAttribute;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlValue;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.namespace.QName;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * TwiML wrapper for @see https://www.twilio.com/docs/api/twiml/conference.
@@ -128,6 +134,9 @@ public class Conference extends TwiML {
     @XmlValue
     private final String name;
 
+    @XmlAnyAttribute
+    private Map<QName, String> options;
+
     private final List<ConferenceEvent> statusCallbackEvents;
 
     // For XML Serialization
@@ -152,6 +161,7 @@ public class Conference extends TwiML {
         this.statusCallback = b.statusCallback;
         this.recordingStatusCallback = b.recordingStatusCallback;
         this.recordingStatusCallbackMethod = b.recordingStatusCallbackMethod;
+        this.options = Maps.newHashMap(b.options);
 
         if (this.statusCallbackEvents != null) {
             this.statusCallbackEvent = Joiner.on(" ").join(Lists.transform(this.statusCallbackEvents, ConferenceEvent.TO_STRING));
@@ -224,6 +234,16 @@ public class Conference extends TwiML {
         return name;
     }
 
+    public Map<String, String> getOptions() {
+        Map<String, String> convertedMap = new HashMap();
+
+        Set<QName> keys = options.keySet();
+        for (QName key : keys) {
+            convertedMap.put(key.getNamespaceURI(), options.get(key));
+        }
+        return convertedMap;
+    }
+
     public static class Builder {
         private Boolean muted;
         private Boolean startConferenceOnEnter;
@@ -241,6 +261,7 @@ public class Conference extends TwiML {
         private String recordingStatusCallback;
         private Method recordingStatusCallbackMethod;
         private String name;
+        private Map<QName, String> options = Maps.newHashMap();
 
         public Builder(String name) {
             this.name = name;
@@ -318,6 +339,11 @@ public class Conference extends TwiML {
 
         public Builder recordingStatusCallbackMethod(Method recordingStatusCallbackMethod) {
             this.recordingStatusCallbackMethod = recordingStatusCallbackMethod;
+            return this;
+        }
+
+        public Builder options(String key, String value) {
+            this.options.put(new QName(key), value);
             return this;
         }
 

--- a/src/main/java/com/twilio/twiml/Dial.java
+++ b/src/main/java/com/twilio/twiml/Dial.java
@@ -193,7 +193,7 @@ public class Dial extends TwiML {
     }
 
     public Map<String, String> getOptions() {
-        Map<String, String> convertedMap = new HashMap();
+        Map<String, String> convertedMap = new HashMap<>();
 
         Set<QName> keys = options.keySet();
         for (QName key : keys) {

--- a/src/main/java/com/twilio/twiml/Dial.java
+++ b/src/main/java/com/twilio/twiml/Dial.java
@@ -1,13 +1,15 @@
 package com.twilio.twiml;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.namespace.QName;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * TwiML wrapper for @see https://www.twilio.com/docs/api/twiml/dial.
@@ -84,13 +86,13 @@ public class Dial extends TwiML {
 
     @SuppressWarnings("checkstyle:indentation")
     @XmlElements({
-        @XmlElement(name = "Number", type = Number.class)
+            @XmlElement(name = "Number", type = Number.class)
     })
     private final List<Number> numbers;
 
     @SuppressWarnings("checkstyle:indentation")
     @XmlElements({
-        @XmlElement(name = "Client", type = Client.class)
+            @XmlElement(name = "Client", type = Client.class)
     })
     private final List<Client> clients;
 
@@ -102,6 +104,9 @@ public class Dial extends TwiML {
 
     @XmlElement(name = "Sip")
     private final Sip sip;
+
+    @XmlAnyAttribute
+    private Map<QName, String> options;
 
     // For XML Serialization
     private Dial() {
@@ -124,6 +129,7 @@ public class Dial extends TwiML {
         this.conference = b.conference;
         this.queue = b.queue;
         this.sip = b.sip;
+        this.options = Maps.newHashMap(b.options);
     }
 
     public Boolean isHangupOnStar() {
@@ -186,6 +192,16 @@ public class Dial extends TwiML {
         return sip;
     }
 
+    public Map<String, String> getOptions() {
+        Map<String, String> convertedMap = new HashMap();
+
+        Set<QName> keys = options.keySet();
+        for (QName key : keys) {
+            convertedMap.put(key.getNamespaceURI(), options.get(key));
+        }
+        return convertedMap;
+    }
+
     public static class Builder {
         private Boolean hangupOnStar;
         private Integer timeout;
@@ -202,6 +218,7 @@ public class Dial extends TwiML {
         private Conference conference;
         private Queue queue;
         private Sip sip;
+        private Map<QName, String> options = Maps.newHashMap();
 
         public Builder hangupOnStar(boolean hangupOnStar) {
             this.hangupOnStar = hangupOnStar;
@@ -275,6 +292,11 @@ public class Dial extends TwiML {
 
         public Builder sip(Sip sip) {
             this.sip = sip;
+            return this;
+        }
+
+        public Builder options(String key, String value) {
+            this.options.put(new QName(key), value);
             return this;
         }
 

--- a/src/main/java/com/twilio/twiml/Pause.java
+++ b/src/main/java/com/twilio/twiml/Pause.java
@@ -37,7 +37,7 @@ public class Pause extends TwiML {
     }
 
     public Map<String, String> getOptions() {
-        Map<String, String> convertedMap = new HashMap();
+        Map<String, String> convertedMap = new HashMap<>();
 
         Set<QName> keys = options.keySet();
         for (QName key : keys) {

--- a/src/main/java/com/twilio/twiml/Pause.java
+++ b/src/main/java/com/twilio/twiml/Pause.java
@@ -1,7 +1,14 @@
 package com.twilio.twiml;
 
+import com.google.common.collect.Maps;
+
+import javax.xml.bind.annotation.XmlAnyAttribute;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.namespace.QName;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * TwiML wrapper for @see https://www.twilio.com/docs/api/twiml/pause.
@@ -12,6 +19,9 @@ public class Pause extends TwiML {
     @XmlAttribute
     private final Integer length;
 
+    @XmlAnyAttribute
+    private Map<QName, String> options;
+
     // For XML Serialization
     private Pause() {
         this(new Builder());
@@ -19,17 +29,34 @@ public class Pause extends TwiML {
 
     private Pause(Builder b) {
         this.length = b.length;
+        this.options = Maps.newHashMap(b.options);
     }
 
     public Integer getLength() {
         return length;
     }
 
+    public Map<String, String> getOptions() {
+        Map<String, String> convertedMap = new HashMap();
+
+        Set<QName> keys = options.keySet();
+        for (QName key : keys) {
+            convertedMap.put(key.getNamespaceURI(), options.get(key));
+        }
+        return convertedMap;
+    }
+
     public static class Builder {
         private Integer length;
+        private Map<QName, String> options = Maps.newHashMap();
 
         public Builder length(int length) {
             this.length = length;
+            return this;
+        }
+
+        public Builder options(String key, String value) {
+            this.options.put(new QName(key), value);
             return this;
         }
 

--- a/src/test/java/com/twilio/twiml/ConferenceTest.java
+++ b/src/test/java/com/twilio/twiml/ConferenceTest.java
@@ -41,4 +41,40 @@ public class ConferenceTest {
 
         Assert.assertEquals("%3CConference+muted%3D%22true%22+startConferenceOnEnter%3D%22true%22+endConferenceOnExit%3D%22false%22+maxParticipants%3D%2210%22+beep%3D%22false%22+record%3D%22do-not-record%22+trim%3D%22do-not-trim%22+waitMethod%3D%22POST%22+waitUrl%3D%22http%3A%2F%2Ftwilio.ca%22%3Emy+conference%3C%2FConference%3E", conference.toUrl());
     }
+
+    @Test
+    public void testOptionsXml() throws TwiMLException {
+        Conference conference = new Conference.Builder("my conference")
+                .muted(true)
+                .startConferenceOnEnter(true)
+                .endConferenceOnExit(false)
+                .maxParticipants(10)
+                .beep(Conference.Beep.FALSE)
+                .record(Conference.Record.DO_NOT_RECORD)
+                .trim(Trim.DO_NOT_TRIM)
+                .waitMethod(Method.POST)
+                .waitUrl("http://twilio.ca")
+                .options("foo", "bar")
+                .build();
+
+        Assert.assertEquals("<Conference muted=\"true\" startConferenceOnEnter=\"true\" endConferenceOnExit=\"false\" maxParticipants=\"10\" beep=\"false\" record=\"do-not-record\" trim=\"do-not-trim\" waitMethod=\"POST\" waitUrl=\"http://twilio.ca\" foo=\"bar\">my conference</Conference>", conference.toXml());
+    }
+
+    @Test
+    public void testOptionsUrl() throws TwiMLException {
+        Conference conference = new Conference.Builder("my conference")
+                .muted(true)
+                .startConferenceOnEnter(true)
+                .endConferenceOnExit(false)
+                .maxParticipants(10)
+                .beep(Conference.Beep.FALSE)
+                .record(Conference.Record.DO_NOT_RECORD)
+                .trim(Trim.DO_NOT_TRIM)
+                .waitMethod(Method.POST)
+                .waitUrl("http://twilio.ca")
+                .options("foo", "bar")
+                .build();
+
+        Assert.assertEquals("%3CConference+muted%3D%22true%22+startConferenceOnEnter%3D%22true%22+endConferenceOnExit%3D%22false%22+maxParticipants%3D%2210%22+beep%3D%22false%22+record%3D%22do-not-record%22+trim%3D%22do-not-trim%22+waitMethod%3D%22POST%22+waitUrl%3D%22http%3A%2F%2Ftwilio.ca%22+foo%3D%22bar%22%3Emy+conference%3C%2FConference%3E", conference.toUrl());
+    }
 }

--- a/src/test/java/com/twilio/twiml/DialTest.java
+++ b/src/test/java/com/twilio/twiml/DialTest.java
@@ -50,4 +50,54 @@ public class DialTest {
 
         Assert.assertEquals("%3CDial+hangupOnStar%3D%22true%22+timeout%3D%228%22+action%3D%22%2Fdial%22+method%3D%22POST%22+callerId%3D%22%2B14155550000%22+trim%3D%22trim-silence%22%3E%3CConference%3Econference%3C%2FConference%3E%3C%2FDial%3E", dial.toUrl());
     }
+
+    @Test
+    public void testOptionsXML() throws TwiMLException {
+        Conference conference = new Conference.Builder("conference")
+                .build();
+
+        Number number = new Number.Builder("+18885551234").build();
+
+        Dial dial = new Dial.Builder()
+                .action("/dial")
+                .callerId("+14155550000")
+                .hangupOnStar(true)
+                .method(Method.POST)
+                .trim(Dial.Trim.TRIM_SILENCE)
+                .timeout(8)
+                .conference(conference)
+                .options("foo", "bar")
+                .options("fizz", "buzz")
+                .number(number)
+                .build();
+
+
+        Assert.assertEquals(
+                "<Dial hangupOnStar=\"true\" timeout=\"8\" action=\"/dial\" method=\"POST\" callerId=\"+14155550000\" trim=\"trim-silence\" fizz=\"buzz\" foo=\"bar\">" +
+                        "<Number>+18885551234</Number>" +
+                        "<Conference>conference</Conference>" +
+                        "</Dial>", dial.toXml());
+
+    }
+
+    @Test
+    public void testOptionsUrl() throws TwiMLException {
+        Conference conference = new Conference.Builder("conference")
+                .build();
+
+        Dial dial = new Dial.Builder()
+                .action("/dial")
+                .callerId("+14155550000")
+                .hangupOnStar(true)
+                .method(Method.POST)
+                .trim(Dial.Trim.TRIM_SILENCE)
+                .timeout(8)
+                .conference(conference)
+                .options("foo", "bar")
+                .options("fizz", "buzz")
+                .build();
+
+        Assert.assertEquals("%3CDial+hangupOnStar%3D%22true%22+timeout%3D%228%22+action%3D%22%2Fdial%22+method%3D%22POST%22+callerId%3D%22%2B14155550000%22+trim%3D%22trim-silence%22+fizz%3D%22buzz%22+foo%3D%22bar%22%3E%3CConference%3Econference%3C%2FConference%3E%3C%2FDial%3E", dial.toUrl());
+
+    }
 }

--- a/src/test/java/com/twilio/twiml/DialTest.java
+++ b/src/test/java/com/twilio/twiml/DialTest.java
@@ -67,13 +67,12 @@ public class DialTest {
                 .timeout(8)
                 .conference(conference)
                 .options("foo", "bar")
-                .options("fizz", "buzz")
                 .number(number)
                 .build();
 
 
         Assert.assertEquals(
-                "<Dial hangupOnStar=\"true\" timeout=\"8\" action=\"/dial\" method=\"POST\" callerId=\"+14155550000\" trim=\"trim-silence\" fizz=\"buzz\" foo=\"bar\">" +
+                "<Dial hangupOnStar=\"true\" timeout=\"8\" action=\"/dial\" method=\"POST\" callerId=\"+14155550000\" trim=\"trim-silence\" foo=\"bar\">" +
                         "<Number>+18885551234</Number>" +
                         "<Conference>conference</Conference>" +
                         "</Dial>", dial.toXml());
@@ -94,10 +93,9 @@ public class DialTest {
                 .timeout(8)
                 .conference(conference)
                 .options("foo", "bar")
-                .options("fizz", "buzz")
                 .build();
 
-        Assert.assertEquals("%3CDial+hangupOnStar%3D%22true%22+timeout%3D%228%22+action%3D%22%2Fdial%22+method%3D%22POST%22+callerId%3D%22%2B14155550000%22+trim%3D%22trim-silence%22+fizz%3D%22buzz%22+foo%3D%22bar%22%3E%3CConference%3Econference%3C%2FConference%3E%3C%2FDial%3E", dial.toUrl());
+        Assert.assertEquals("%3CDial+hangupOnStar%3D%22true%22+timeout%3D%228%22+action%3D%22%2Fdial%22+method%3D%22POST%22+callerId%3D%22%2B14155550000%22+trim%3D%22trim-silence%22+foo%3D%22bar%22%3E%3CConference%3Econference%3C%2FConference%3E%3C%2FDial%3E", dial.toUrl());
 
     }
 }

--- a/src/test/java/com/twilio/twiml/PauseTest.java
+++ b/src/test/java/com/twilio/twiml/PauseTest.java
@@ -25,4 +25,24 @@ public class PauseTest {
 
         Assert.assertEquals("%3CPause+length%3D%225%22%2F%3E", pause.toUrl());
     }
+
+    @Test
+    public void testOptionsXml() throws TwiMLException {
+        Pause pause = new Pause.Builder()
+                .length(5)
+                .options("foo", "bar")
+                .build();
+
+        Assert.assertEquals("<Pause length=\"5\" foo=\"bar\"/>", pause.toXml());
+    }
+
+    @Test
+    public void testOptionsUrl() throws TwiMLException {
+        Pause pause = new Pause.Builder()
+                .length(5)
+                .options("foo", "bar")
+                .build();
+
+        Assert.assertEquals("%3CPause+length%3D%225%22+foo%3D%22bar%22%2F%3E", pause.toUrl());
+    }
 }


### PR DESCRIPTION
According to the wiki only `Conference, Dial, and Pause` have undocumented options. However, for consistency should we add this option to all TwiML verbs - in my opinion no. 