### PR TITLE
Fix exception parsing rfc2822 dates for some locales, always use US locale

### DIFF
--- a/src/main/java/com/twilio/converter/DateConverter.java
+++ b/src/main/java/com/twilio/converter/DateConverter.java
@@ -1,5 +1,6 @@
 package com.twilio.converter;
 
+import java.util.Locale;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
@@ -16,7 +17,7 @@ public class DateConverter {
         DateTimeFormat.forPattern(DATE_PATTERN).withZone(DateTimeZone.UTC);
 
     private static final DateTimeFormatter RFC2822_DATE_TIME_FORMATTER =
-        DateTimeFormat.forPattern(RFC2822_DATE_TIME).withZone(DateTimeZone.UTC);
+        DateTimeFormat.forPattern(RFC2822_DATE_TIME).withZone(DateTimeZone.UTC).withLocale(new Locale("en_US"));
 
     private static final DateTimeFormatter ISO8601_DATE_TIME_FORMATTER =
         DateTimeFormat.forPattern(ISO8601_DATE_TIME).withZone(DateTimeZone.UTC);

--- a/src/test/java/com/twilio/converter/DateConverterTest.java
+++ b/src/test/java/com/twilio/converter/DateConverterTest.java
@@ -71,9 +71,16 @@ public class DateConverterTest {
     }
 
     @Test
-    public void testDifferentLocal() {
+    public void testDifferentLocaleRFC2822() {
         Locale.setDefault(new Locale("fr", "CA"));
         DateTime dateTime = DateConverter.rfc2822DateTimeFromString("Tue, 29 Mar 2016 13:00:05 +0000");
+        Assert.assertNotNull(dateTime);
+    }
+
+    @Test
+    public void testDifferentLocaleISO8601() {
+        Locale.setDefault(new Locale("fr", "CA"));
+        DateTime dateTime = DateConverter.iso8601DateTimeFromString("2016-01-15T21:49:24Z");
         Assert.assertNotNull(dateTime);
     }
 }

--- a/src/test/java/com/twilio/converter/DateConverterTest.java
+++ b/src/test/java/com/twilio/converter/DateConverterTest.java
@@ -5,6 +5,8 @@ import org.joda.time.LocalDate;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Locale;
+
 /**
  * Test Class for {@link DateConverter}.
  */
@@ -66,5 +68,12 @@ public class DateConverterTest {
     public void testLocalDateToString() {
         String date = DateConverter.dateStringFromLocalDate(new LocalDate(2016, 9, 21));
         Assert.assertEquals("2016-09-21", date);
+    }
+
+    @Test
+    public void testDifferentLocal() {
+        Locale.setDefault(new Locale("fr", "CA"));
+        DateTime dateTime = DateConverter.rfc2822DateTimeFromString("Tue, 29 Mar 2016 13:00:05 +0000");
+        Assert.assertNotNull(dateTime);
     }
 }


### PR DESCRIPTION
Fix for https://github.com/twilio/twilio-java/issues/303