### PR TITLE
Fix PhoneNumberPrice deserialization

### DIFF
--- a/src/main/java/com/twilio/type/PhoneNumberPrice.java
+++ b/src/main/java/com/twilio/type/PhoneNumberPrice.java
@@ -70,7 +70,7 @@ public class PhoneNumberPrice {
     @JsonCreator
     public PhoneNumberPrice(@JsonProperty("base_price") final double basePrice,
                             @JsonProperty("current_price") final double currentPrice,
-                            @JsonProperty("type") final Type type) {
+                            @JsonProperty("number_type") final Type type) {
         this.basePrice = basePrice;
         this.currentPrice = currentPrice;
         this.type = type;

--- a/src/test/java/com/twilio/type/PhoneNumberPriceTest.java
+++ b/src/test/java/com/twilio/type/PhoneNumberPriceTest.java
@@ -15,7 +15,7 @@ public class PhoneNumberPriceTest extends TypeTest {
         String json = "{\n" +
             "    \"base_price\": 1.00,\n" +
             "    \"current_price\": 2.00,\n" +
-            "    \"type\": \"mobile\"\n" +
+            "    \"number_type\": \"mobile\"\n" +
             "}";
 
         PhoneNumberPrice pnp = fromJson(json, PhoneNumberPrice.class);


### PR DESCRIPTION
The Twilio REST API returns the key "number_type" instead of "type".
https://www.twilio.com/docs/api/pricing/phonenumbers#phone-number-price

<img width="576" alt="fix-pricing-example" src="https://cloud.githubusercontent.com/assets/957202/23173181/4c5f5a3e-f826-11e6-91aa-3817d3db5c47.png">

This pull request solves the issue [DEVED-2155](https://issues.corp.twilio.com/browse/DEVED-2155).