### PR TITLE
add test equals() on request

### DIFF
--- a/src/test/java/com/twilio/http/RequestTest.java
+++ b/src/test/java/com/twilio/http/RequestTest.java
@@ -166,5 +166,13 @@ public class RequestTest {
         assertTrue(request.requiresAuthentication());
     }
 
+    @Test
+    public void testEquals() {
+        Request request = new Request(HttpMethod.DELETE, "/uri");
+        request.setAuth("username", "password");
+        assertFalse(request.equals(new Object()));
+        assertFalse(request.equals(null));
+    }
+
 }
 


### PR DESCRIPTION
Hi,

I propose this changes to [specify](https://github.com/twilio/twilio-java/blob/master/src/main/java/com/twilio/http/Request.java#L259) the `equals()` method of `com.twilio.http.Request`, against object and null value