### PR TITLE
Bump up Jackson dependencies to version 2.8.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </developers>
 
   <properties>
-    <jackson.version>2.4.3</jackson.version>
+    <jackson.version>2.8.7</jackson.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/twilio/jwt/taskrouter/Policy.java
+++ b/src/main/java/com/twilio/jwt/taskrouter/Policy.java
@@ -1,13 +1,9 @@
 package com.twilio.jwt.taskrouter;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.twilio.http.HttpMethod;
@@ -17,7 +13,7 @@ import java.io.IOException;
 import java.util.Map;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Policy {
 
     @JsonProperty("url")

--- a/src/main/java/com/twilio/taskrouter/TaskRouting.java
+++ b/src/main/java/com/twilio/taskrouter/TaskRouting.java
@@ -2,16 +2,16 @@ package com.twilio.taskrouter;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.MoreObjects;
 
 import java.io.IOException;
 import java.util.List;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TaskRouting extends TaskRouterResource {
 
     @JsonProperty("filters")

--- a/src/main/java/com/twilio/taskrouter/Workflow.java
+++ b/src/main/java/com/twilio/taskrouter/Workflow.java
@@ -1,6 +1,10 @@
 package com.twilio.taskrouter;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.MoreObjects;
 

--- a/src/main/java/com/twilio/taskrouter/Workflow.java
+++ b/src/main/java/com/twilio/taskrouter/Workflow.java
@@ -1,11 +1,7 @@
 package com.twilio.taskrouter;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.MoreObjects;
 
 import java.io.IOException;
@@ -13,7 +9,7 @@ import java.util.List;
 
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Workflow extends TaskRouterResource {
 
     @JsonProperty("task_routing")

--- a/src/main/java/com/twilio/taskrouter/WorkflowRule.java
+++ b/src/main/java/com/twilio/taskrouter/WorkflowRule.java
@@ -1,16 +1,18 @@
 package com.twilio.taskrouter;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.MoreObjects;
 
 import java.io.IOException;
 import java.util.List;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.*;
-
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-@JsonInclude(Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowRule extends TaskRouterResource {
 
     private final String expression;

--- a/src/main/java/com/twilio/taskrouter/WorkflowRule.java
+++ b/src/main/java/com/twilio/taskrouter/WorkflowRule.java
@@ -1,18 +1,16 @@
 package com.twilio.taskrouter;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.MoreObjects;
 
 import java.io.IOException;
 import java.util.List;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.*;
+
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonInclude(Include.NON_NULL)
 public class WorkflowRule extends TaskRouterResource {
 
     private final String expression;

--- a/src/main/java/com/twilio/taskrouter/WorkflowRuleTarget.java
+++ b/src/main/java/com/twilio/taskrouter/WorkflowRuleTarget.java
@@ -2,15 +2,15 @@ package com.twilio.taskrouter;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.MoreObjects;
 
 import java.io.IOException;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowRuleTarget extends TaskRouterResource {
 
     @JsonProperty("queue")

--- a/src/test/java/com/twilio/converter/CurrencyDeserializerTest.java
+++ b/src/test/java/com/twilio/converter/CurrencyDeserializerTest.java
@@ -1,6 +1,7 @@
 package com.twilio.converter;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.junit.Assert;
@@ -23,7 +24,7 @@ public class CurrencyDeserializerTest {
         Assert.assertEquals("USD", c.currency.getCurrencyCode());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = JsonMappingException.class)
     public void testInvalidCurrency() throws IOException {
         String json = "{ \"currency\": \"poo\" }";
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
Related to [DEVED-2178](https://issues.corp.twilio.com/browse/DEVED-2178). It should remove some pain points when using twilio-java along other libraries with newer versions of the Jackson library.