### PR TITLE
Allow passing custom HttpClientBuilder to NetworkHttpClient

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 twilio-java changelog
 =====================
 
+[2017-03-21] Version 7.7.1
+--------------------------
+- Allow customizing configuration for NetworkHttpClient
+
 [2017-03-10] Version 7.7.0
 --------------------------
 - Bump Jackson dependency to 2.8.7

--- a/src/main/java/com/twilio/http/NetworkHttpClient.java
+++ b/src/main/java/com/twilio/http/NetworkHttpClient.java
@@ -52,6 +52,22 @@ public class NetworkHttpClient extends HttpClient {
     }
 
     /**
+     * Create a new HTTP Client using custom configuration
+     */
+    public NetworkHttpClient(HttpClientBuilder clientBuilder){
+        Collection<Header> headers = Lists.<Header>newArrayList(
+                new BasicHeader("X-Twilio-Client", "java-" + Twilio.VERSION),
+                new BasicHeader(HttpHeaders.USER_AGENT, "twilio-java/" + Twilio.VERSION + " (" + Twilio.JAVA_VERSION + ") custom"),
+                new BasicHeader(HttpHeaders.ACCEPT, "application/json"),
+                new BasicHeader(HttpHeaders.ACCEPT_ENCODING, "utf-8")
+        );
+
+        client = clientBuilder
+                .setDefaultHeaders(headers)
+                .build();
+    }
+
+    /**
      * Make a request.
      *
      * @param request request to make


### PR DESCRIPTION
Example: Not using system properties as defaults:

```java
HttpClientBuilder clientBuilder = HttpClientBuilder.create();
NetworkHttpClient twilioClient = new NetworkHttpClient(clientBuilder);
```