### PR TITLE
Ensuring all HTTP connections are properly closed

### DIFF
--- a/src/main/java/com/twilio/http/NetworkHttpClient.java
+++ b/src/main/java/com/twilio/http/NetworkHttpClient.java
@@ -7,6 +7,8 @@ import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -95,14 +97,23 @@ public class NetworkHttpClient extends HttpClient {
             }
         }
 
+        HttpResponse response = null;
+
         try {
-            HttpResponse response = client.execute(builder.build());
+            response = client.execute(builder.build());
             return new Response(
-                response.getEntity() == null ? null : response.getEntity().getContent(),
+
+                // Consume the entire HTTP response before returning the stream
+                response.getEntity() == null ? null : new BufferedHttpEntity(response.getEntity()).getContent(),
                 response.getStatusLine().getStatusCode()
             );
         } catch (IOException e) {
             throw new ApiException(e.getMessage());
+        } finally {
+
+            // Ensure this response is properly closed
+            HttpClientUtils.closeQuietly(response);
+
         }
 
     }


### PR DESCRIPTION
Hello, and great work on this library!

We've recently discovered an HTTP connection leak can occur under network edge conditions. 

This is a pull request that ensures that "... that the entity content has been fully consumed **and** the underlying stream has been closed" (https://hc.apache.org/httpcomponents-client-4.5.x/tutorial/html/fundamentals.html)

Specifically, the code below reads the full response (while still preserving the code's dependency on accessing the response InputStream), as well as guaranteeing that the response is closed. Both of these steps are important, and are consistent with the HttpClient recommendations.

Let me know if you have any questions! We've been running these modifications in Production for several days now and have not seen the connection leak since.
