### PR TITLE
Strip default ports in RequestCanonicalizer

### DIFF
--- a/src/main/java/com/twilio/jwt/validation/RequestCanonicalizer.java
+++ b/src/main/java/com/twilio/jwt/validation/RequestCanonicalizer.java
@@ -172,7 +172,7 @@ class RequestCanonicalizer {
     private static Function<Header[], Header[]> NORMALIZE_HEADERS = new Function<Header[], Header[]>() {
         @Override
         public Header[] apply(Header[] headers) {
-            Header[] newHeaders = new Header[headers.length];
+            Header[] normalizedHeaders = new Header[headers.length];
             for (int i = 0; i < headers.length; i++) {
                 String headerName = headers[i].getName().toLowerCase();
                 String headerValue = headers[i].getValue();
@@ -181,10 +181,10 @@ class RequestCanonicalizer {
                     headerValue = headerValue.split(":")[0];
                 }
 
-                newHeaders[i] = new BasicHeader(headerName, headerValue);
+                normalizedHeaders[i] = new BasicHeader(headerName, headerValue);
             }
 
-            return newHeaders;
+            return normalizedHeaders;
         }
     };
 

--- a/src/main/java/com/twilio/jwt/validation/RequestCanonicalizer.java
+++ b/src/main/java/com/twilio/jwt/validation/RequestCanonicalizer.java
@@ -177,7 +177,7 @@ class RequestCanonicalizer {
                 String headerName = headers[i].getName().toLowerCase();
                 String headerValue = headers[i].getValue();
 
-                if (headerName.equals("host") && (headerValue.contains(":443") || headerValue.contains(":80"))) {
+                if (headerName.equals("host") && (headerValue.endsWith(":443") || headerValue.endsWith(":80"))) {
                     headerValue = headerValue.split(":")[0];
                 }
 

--- a/src/test/java/com/twilio/jwt/validation/RequestCanonicalizerTest.java
+++ b/src/test/java/com/twilio/jwt/validation/RequestCanonicalizerTest.java
@@ -52,6 +52,25 @@ public class RequestCanonicalizerTest {
     }
 
     @Test
+    public void testCreateCanonicalRequestWithHostPort() throws Exception {
+        String queryParams = "PageSize=5&Limit=10";
+        headers[0] = new BasicHeader("host", "api.twilio.com:443");
+
+        String canonicalRequest = canonicalizeWithQueryParams(queryParams);
+
+        Assert.assertEquals("GET\n" + // action
+                            "/Messages\n" + // path
+                            "Limit=10&PageSize=5\n" + //queryParams
+                            "authorization:foobar\n" + // included header #1
+                            "duplicate:value1,value2\n" + // included header #2
+                            "host:api.twilio.com\n" + // included headar #3
+                            "\n" + // empty line after headers
+                            "authorization;duplicate;host\n" + // included headers
+                            "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2", // body hash
+                            canonicalRequest);
+    }
+
+    @Test
     public void testReplacesEncodedWhitespaceInQueryParams() throws Exception {
         String queryParams = "key+with+whitespace=value+with+whitespace";
 

--- a/src/test/java/com/twilio/jwt/validation/ValidationTokenTest.java
+++ b/src/test/java/com/twilio/jwt/validation/ValidationTokenTest.java
@@ -132,6 +132,33 @@ public class ValidationTokenTest {
         Assert.assertEquals("bd792c967c20d546c738b94068f5f72758a10d26c12979677501e1eefe58c65a", claims.get("rqh"));
     }
 
+    @Test
+    public void testTokenFromHttpRequestWithHostPort() throws IOException {
+        headers[0] = new BasicHeader("host", "api.twilio.com:443");
+        new Expectations() {{
+            request.getRequestLine().getMethod();
+            result = "GET";
+
+            request.getRequestLine().getUri();
+            result = "/Messages?PageSize=5&Limit=10";
+
+            request.getAllHeaders();
+            result = headers;
+        }};
+
+        Jwt jwt = ValidationToken.fromHttpRequest(ACCOUNT_SID, CREDENTIAL_SID, SIGNING_KEY_SID, privateKey, request, SIGNED_HEADERS);
+        Claims claims =
+                Jwts.parser()
+                    .setSigningKey(privateKey)
+                    .parseClaimsJws(jwt.toJwt())
+                    .getBody();
+
+
+        this.validateToken(claims);
+        Assert.assertEquals("authorization;host", claims.get("hrh"));
+        Assert.assertEquals("4b3d2666845a38f00259a5231a08765bb2d12564bc4469fd5b2816204c588967", claims.get("rqh"));
+    }
+
     private void validateToken(Claims claims) {
         Assert.assertEquals(SIGNING_KEY_SID, claims.getIssuer());
         Assert.assertEquals(ACCOUNT_SID, claims.getSubject());


### PR DESCRIPTION
Generalizes the LOWERCASE_KEYS function into NORMALIZE_HEADERS.  Additionally strips default ports on the Host header for signature generation (PKCV). 