### PR TITLE
Add jsonToMap in converter

### DIFF
--- a/src/main/java/com/twilio/converter/Converter.java
+++ b/src/main/java/com/twilio/converter/Converter.java
@@ -4,6 +4,8 @@ package com.twilio.converter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class Converter {
@@ -20,6 +22,20 @@ public class Converter {
         try {
             return MAPPER.writeValueAsString(map);
         } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Convert a JSON String to a map.
+     *
+     * @param json string representing the json hash map
+     * @return HashMap read
+     */
+    public static Map<String, Object> jsonToMap(final String json) {
+        try {
+            return MAPPER.readValue(json, HashMap.class);
+        } catch (IOException e) {
             return null;
         }
     }


### PR DESCRIPTION
This PR add a `jsonToMap` converter convenience method for use with the `Map<String, Object>` params, like the one found in [`Composition.java`](https://github.com/twilio/twilio-java/blob/master/src/main/java/com/twilio/rest/video/v1/Composition.java#L218). This would allow users to write code like so

```
        final String videoLayout = "{"
                + "   \"main\": {"
                + "       \"z_pos\": 1,"
                + "       \"video_sources\":[\"RTxx\"]"
                + "    },"
                + "   \"row\": {"
                + "       \"z_pos\": 2,"
                + "       \"x_pos\": 10,"
                + "       \"y_pos\": 530,"
                + "       \"width\": 1260,"
                + "       \"height\": 160,"
                + "       \"max_rows\": 1,"
                + "       \"video_sources\": [\"*\"],"
                + "       \"video_sources_excluded\": [\"RTxx\"]"
                + "    }"
                + "}";

        Composition composition = Composition.creator()
                .setRoomSid("RMxx")
                .setAudioSources("*")
                .setVideoLayout(Converter.jsonToMap(videoLayout, HashMap.class))
                .setStatusCallback("https://callback.host.com/composer-callback")
                .setStatusCallbackMethod(HttpMethod.GET)
                .setFormat(Format.MP4)
                .create();
```