### PR TITLE
Convenience method for verifying your connection with the new SSL certificate

### DIFF
--- a/src/main/java/com/twilio/Twilio.java
+++ b/src/main/java/com/twilio/Twilio.java
@@ -2,8 +2,14 @@ package com.twilio;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.twilio.http.TwilioRestClient;
+
+import com.twilio.exception.ApiException;
 import com.twilio.exception.AuthenticationException;
+import com.twilio.http.HttpMethod;
+import com.twilio.http.NetworkHttpClient;
+import com.twilio.http.Request;
+import com.twilio.http.Response;
+import com.twilio.http.TwilioRestClient;
 
 import java.util.concurrent.Executors;
 
@@ -153,6 +159,21 @@ public class Twilio {
      */
     public static void setExecutorService(final ListeningExecutorService executorService) {
         Twilio.executorService = executorService;
+    }
+
+    /**
+     * Check for an upgraded SSL certificate on api.twilio.com. Returns true if a new certificate was found, or
+     * false if no upgrade certificate is posted. If the check fails,
+     */
+    public static boolean validateSslCertificate() {
+        final NetworkHttpClient client = new NetworkHttpClient();
+        final Request request = new Request(HttpMethod.GET, "https://api.twilio.com:8443");
+        final Response response = client.makeRequest(request);
+        if (!TwilioRestClient.SUCCESS.apply(response.getStatusCode())) {
+            throw new ApiException("Unexpected response");
+        }
+
+        return true;
     }
 
     /**

--- a/src/main/java/com/twilio/Twilio.java
+++ b/src/main/java/com/twilio/Twilio.java
@@ -162,18 +162,20 @@ public class Twilio {
     }
 
     /**
-     * Check for an upgraded SSL certificate on api.twilio.com. Returns true if a new certificate was found, or
-     * false if no upgrade certificate is posted. If the check fails,
+     * Validate that we can connect to the new SSL certificate posted on api.twilio.com. Returns true if the
+     * connection was successful, or false if the connection failed.
      */
     public static boolean validateSslCertificate() {
         final NetworkHttpClient client = new NetworkHttpClient();
         final Request request = new Request(HttpMethod.GET, "https://api.twilio.com:8443");
-        final Response response = client.makeRequest(request);
-        if (!TwilioRestClient.SUCCESS.apply(response.getStatusCode())) {
-            throw new ApiException("Unexpected response");
-        }
 
-        return true;
+        try {
+            final Response response = client.makeRequest(request);
+
+            return TwilioRestClient.SUCCESS.apply(response.getStatusCode());
+        } catch (final ApiException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/com/twilio/TwilioTest.java
+++ b/src/test/java/com/twilio/TwilioTest.java
@@ -20,6 +20,7 @@ import mockit.Mocked;
 import mockit.NonStrictExpectations;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -83,22 +84,31 @@ public class TwilioTest {
     @Test
     public void testValidateSslCertificateError() {
         new NonStrictExpectations() {{
-            Request request = new Request(HttpMethod.GET, "https://api.twilio.com:8443");
+            final Request request = new Request(HttpMethod.GET, "https://api.twilio.com:8443");
             networkHttpClient.makeRequest(request);
             times = 1;
             result = new Response("", 500);
         }};
 
-        try {
-            Twilio.validateSslCertificate();
-            fail("Expected ApiException to be thrown for 500");
-        } catch (ApiException e) {}
+        assertFalse(Twilio.validateSslCertificate());
+    }
+
+    @Test
+    public void testValidateSslCertificateException() {
+        new NonStrictExpectations() {{
+            final Request request = new Request(HttpMethod.GET, "https://api.twilio.com:8443");
+            networkHttpClient.makeRequest(request);
+            times = 1;
+            result = new ApiException("No");
+        }};
+
+        assertFalse(Twilio.validateSslCertificate());
     }
 
     @Test
     public void testValidateSslCertificateSuccess() {
         new NonStrictExpectations() {{
-            Request request = new Request(HttpMethod.GET, "https://api.twilio.com:8443");
+            final Request request = new Request(HttpMethod.GET, "https://api.twilio.com:8443");
             networkHttpClient.makeRequest(request);
             times = 1;
             result = new Response("", 200);


### PR DESCRIPTION
Add new method `Twilio.validateSslCertificate`, which returns a boolean value telling you whether you're able to connect to the updated SSL certificate endpoint.