### PR TITLE
Add Dockerfile and related changes to build the Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ notifications:
       - secure: MkRPjhMDkLMT0tKhSzSAEEdLxKlFrcEw00FBgpcpIl50kSpe3gxCJsm2bz5+LySblCfY1nI5D1+R++eB5cxJzgZvEBWIXQnGJVAV+X7WW1CI1FBZlv6FNLBe5gVPPzo5kIIM1g3o7AaERcraHK9h9S9N8cpnBRHe+Xf6wTRqmwo=
       - secure: iRd6XcgHGFSJ/eS1ZwCUgUVTK0a+JAPmyPEx/OdFbma6DvF8WBhWtW5Q1dyrjQ3JWU8DW2Att9jRnGHd9F5wWWcykxYbD9DXrlfqCZpec9pHzEMAud9MG1PqK0d3y2oyjwps/fQ092PJcn9/y7zX6tzdVWKaKUe4iRDs1u1ehUo=
 deploy:
-  script:
-    - make docker-build
-    - make docker-push
-  on: tags
+  provider: script
+  script: make docker-build && make docker-push
+  skip_cleanup: true
+  on:
+    tags: true
+    jdk: "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ notifications:
     rooms:
       - secure: MkRPjhMDkLMT0tKhSzSAEEdLxKlFrcEw00FBgpcpIl50kSpe3gxCJsm2bz5+LySblCfY1nI5D1+R++eB5cxJzgZvEBWIXQnGJVAV+X7WW1CI1FBZlv6FNLBe5gVPPzo5kIIM1g3o7AaERcraHK9h9S9N8cpnBRHe+Xf6wTRqmwo=
       - secure: iRd6XcgHGFSJ/eS1ZwCUgUVTK0a+JAPmyPEx/OdFbma6DvF8WBhWtW5Q1dyrjQ3JWU8DW2Att9jRnGHd9F5wWWcykxYbD9DXrlfqCZpec9pHzEMAud9MG1PqK0d3y2oyjwps/fQ092PJcn9/y7zX6tzdVWKaKUe4iRDs1u1ehUo=
+deploy:
+  script:
+    - make docker-build
+    - make docker-push
+  on: tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 jdk:
   - oraclejdk8
   - openjdk7
+services:
+  - docker
 notifications:
   slack:
     on_success: change

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8
+
+RUN mkdir /twilio
+WORKDIR /twilio
+
+COPY src ./src
+COPY pom.xml .
+
+RUN apt-get update && apt-get install maven -y
+RUN mvn clean install -Dmaven.test.skip=true

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,14 @@ test:
 
 docs:
 	mvn javadoc:javadoc
+
+API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cut -d ' ' -f 5)
+docker-build:
+	docker build -t twilio/twilio-java .
+	docker tag twilio/twilio-java twilio/twilio-java:${TRAVIS_TAG}
+	docker tag twilio/twilio-java twilio/twilio-java:${API_DEFINITIONS_SHA}
+
+docker-push:
+	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+	docker push twilio/twilio-java:${TRAVIS_TAG}
+	docker push twilio/twilio-java:${API_DEFINITIONS_TAG}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ docker-build:
 	docker tag twilio/twilio-java twilio/twilio-java:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
-	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+	echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 	docker push twilio/twilio-java:${TRAVIS_TAG}
-	docker push twilio/twilio-java:apidefs-${API_DEFINITIONS_TAG}
+	docker push twilio/twilio-java:apidefs-${API_DEFINITIONS_SHA}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ docker-build:
 	docker tag twilio/twilio-java twilio/twilio-java:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
-	echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+	echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 	docker push twilio/twilio-java:${TRAVIS_TAG}
 	docker push twilio/twilio-java:apidefs-${API_DEFINITIONS_SHA}

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cu
 docker-build:
 	docker build -t twilio/twilio-java .
 	docker tag twilio/twilio-java twilio/twilio-java:${TRAVIS_TAG}
-	docker tag twilio/twilio-java twilio/twilio-java:${API_DEFINITIONS_SHA}
+	docker tag twilio/twilio-java twilio/twilio-java:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
 	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
 	docker push twilio/twilio-java:${TRAVIS_TAG}
-	docker push twilio/twilio-java:${API_DEFINITIONS_TAG}
+	docker push twilio/twilio-java:apidefs-${API_DEFINITIONS_TAG}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ That will output XML that looks like this:
 
 The documentation for the Twilio API can be found [here.](http://twilio.com/docs/api)
 
+## Docker Image
+
+The `Dockerfile` present in this repository and its respective `twilio/twilio-ruby` Docker image are used by Twilio for testing purposes only.
+
 # Getting help
 
 If you need help installing or using the library, please contact Twilio Support

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The documentation for the Twilio API can be found [here.](http://twilio.com/docs
 
 ## Docker Image
 
-The `Dockerfile` present in this repository and its respective `twilio/twilio-ruby` Docker image are used by Twilio for testing purposes only.
+The `Dockerfile` present in this repository and its respective `twilio/twilio-java` Docker image are currently used by Twilio for testing purposes only.
 
 # Getting help
 


### PR DESCRIPTION
Hi there!

This PR adds the Dockerfile and related files to build the lib Docker image. This image will be used mainly by Tricorder to generate further Tricorder worker images with the specific lib version.

The tags used in the Docker images are the version (from the release tag) and the api-definitions SHA from the release.

TODO:
- [ ] Add Docker Hub credentials to the TravisCI env
- [ ] Merge and create a release for testing