### PR TITLE
Allow adding TwiML children with generic tag names

### DIFF
--- a/src/main/java/com/twilio/twiml/GenericNode.java
+++ b/src/main/java/com/twilio/twiml/GenericNode.java
@@ -1,0 +1,23 @@
+package com.twilio.twiml;
+
+
+public class GenericNode extends TwiML {
+    protected GenericNode(Builder builder) {
+        super(builder.tag, builder);
+    }
+
+    public static class Builder extends TwiML.Builder<Builder> {
+        private String tag;
+
+        public Builder(String tag) {
+            this.tag = tag;
+        }
+
+        /**
+         * Create and return resulting {@code <Response>} element
+         */
+        public GenericNode build() {
+            return new GenericNode(this);
+        }
+    }
+}

--- a/src/main/java/com/twilio/twiml/GenericNode.java
+++ b/src/main/java/com/twilio/twiml/GenericNode.java
@@ -14,7 +14,7 @@ public class GenericNode extends TwiML {
         }
 
         /**
-         * Create and return resulting {@code <Response>} element
+         * Create and return resulting {@code <GenericNode>} element
          */
         public GenericNode build() {
             return new GenericNode(this);

--- a/src/main/java/com/twilio/twiml/TwiML.java
+++ b/src/main/java/com/twilio/twiml/TwiML.java
@@ -185,7 +185,6 @@ public abstract class TwiML {
             .toString();
     }
 
-
     /**
      * Create a new {@code TwiML} node
      */

--- a/src/main/java/com/twilio/twiml/TwiML.java
+++ b/src/main/java/com/twilio/twiml/TwiML.java
@@ -51,7 +51,7 @@ public abstract class TwiML {
      *
      * @return A Map of attribute keys to values
      */
-    protected Map<String, String> getElementAttributes() {
+    protected Map<String,String> getElementAttributes() {
         return new HashMap<>();
     }
 
@@ -90,7 +90,7 @@ public abstract class TwiML {
             node.appendChild(parentDoc.createTextNode(body));
         }
 
-        for (Map.Entry<String, String> attr : this.getElementAttributes().entrySet()) {
+        for (Map.Entry<String,String> attr : this.getElementAttributes().entrySet()) {
             node.setAttribute(attr.getKey(), attr.getValue());
         }
 
@@ -113,9 +113,9 @@ public abstract class TwiML {
     public String toXml() throws TwiMLException {
         try {
             Document doc = DocumentBuilderFactory
-                    .newInstance()
-                    .newDocumentBuilder()
-                    .newDocument();
+                .newInstance()
+                .newDocumentBuilder()
+                .newDocument();
             doc.setXmlStandalone(true);
             doc.appendChild(this.buildXmlElement(doc));
 
@@ -158,40 +158,38 @@ public abstract class TwiML {
 
         TwiML twiml = (TwiML) o;
         return Objects.equal(this.getTagName(), twiml.getTagName()) &&
-                Objects.equal(this.getElementBody(), twiml.getElementBody()) &&
-                Objects.equal(this.getElementAttributes(), twiml.getElementAttributes()) &&
-                Objects.equal(this.getOptions(), twiml.getOptions()) &&
-                Objects.equal(this.getChildren(), twiml.getChildren());
+            Objects.equal(this.getElementBody(), twiml.getElementBody()) &&
+            Objects.equal(this.getElementAttributes(), twiml.getElementAttributes()) &&
+            Objects.equal(this.getOptions(), twiml.getOptions()) &&
+            Objects.equal(this.getChildren(), twiml.getChildren());
     }
 
     @Override
     public int hashCode() {
         return Objects.hashCode(
-                this.getTagName(),
-                this.getElementBody(),
-                this.getElementAttributes(),
-                this.getChildren(),
-                this.getOptions()
+            this.getTagName(),
+            this.getElementBody(),
+            this.getElementAttributes(),
+            this.getChildren(),
+            this.getOptions()
         );
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("Body", this.getElementBody())
-                .add("Attributes", this.getElementAttributes())
-                .add("Children", this.getChildren())
-                .add("Options", this.getOptions())
-                .toString();
+            .add("Body", this.getElementBody())
+            .add("Attributes", this.getElementAttributes())
+            .add("Children", this.getChildren())
+            .add("Options", this.getOptions())
+            .toString();
     }
-
 
 
     /**
      * Create a new {@code TwiML} node
      */
     public static class Builder<T extends Builder<T>> {
-
         protected Map<String, String> options = new HashMap<>();
         protected List<TwiML> children = new ArrayList<>();
 
@@ -222,5 +220,4 @@ public abstract class TwiML {
 
 
     }
-
 }

--- a/src/main/java/com/twilio/twiml/TwiML.java
+++ b/src/main/java/com/twilio/twiml/TwiML.java
@@ -55,6 +55,9 @@ public abstract class TwiML {
         return new HashMap<>();
     }
 
+    public Builder getBuilder() {
+        return this.builder;
+    }
     /**
      * Get tag name of this TwiML Element.
      */
@@ -87,7 +90,7 @@ public abstract class TwiML {
             node.appendChild(parentDoc.createTextNode(body));
         }
 
-        for (Map.Entry<String,String> attr : this.getElementAttributes().entrySet()) {
+        for (Map.Entry<String, String> attr : this.getElementAttributes().entrySet()) {
             node.setAttribute(attr.getKey(), attr.getValue());
         }
 
@@ -110,9 +113,9 @@ public abstract class TwiML {
     public String toXml() throws TwiMLException {
         try {
             Document doc = DocumentBuilderFactory
-                .newInstance()
-                .newDocumentBuilder()
-                .newDocument();
+                    .newInstance()
+                    .newDocumentBuilder()
+                    .newDocument();
             doc.setXmlStandalone(true);
             doc.appendChild(this.buildXmlElement(doc));
 
@@ -155,37 +158,40 @@ public abstract class TwiML {
 
         TwiML twiml = (TwiML) o;
         return Objects.equal(this.getTagName(), twiml.getTagName()) &&
-            Objects.equal(this.getElementBody(), twiml.getElementBody()) &&
-            Objects.equal(this.getElementAttributes(), twiml.getElementAttributes()) &&
-            Objects.equal(this.getOptions(), twiml.getOptions()) &&
-            Objects.equal(this.getChildren(), twiml.getChildren());
+                Objects.equal(this.getElementBody(), twiml.getElementBody()) &&
+                Objects.equal(this.getElementAttributes(), twiml.getElementAttributes()) &&
+                Objects.equal(this.getOptions(), twiml.getOptions()) &&
+                Objects.equal(this.getChildren(), twiml.getChildren());
     }
 
     @Override
     public int hashCode() {
         return Objects.hashCode(
-            this.getTagName(),
-            this.getElementBody(),
-            this.getElementAttributes(),
-            this.getChildren(),
-            this.getOptions()
+                this.getTagName(),
+                this.getElementBody(),
+                this.getElementAttributes(),
+                this.getChildren(),
+                this.getOptions()
         );
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("Body", this.getElementBody())
-            .add("Attributes", this.getElementAttributes())
-            .add("Children", this.getChildren())
-            .add("Options", this.getOptions())
-            .toString();
+                .add("Body", this.getElementBody())
+                .add("Attributes", this.getElementAttributes())
+                .add("Children", this.getChildren())
+                .add("Options", this.getOptions())
+                .toString();
     }
+
+
 
     /**
      * Create a new {@code TwiML} node
      */
     public static class Builder<T extends Builder<T>> {
+
         protected Map<String, String> options = new HashMap<>();
         protected List<TwiML> children = new ArrayList<>();
 
@@ -205,5 +211,16 @@ public abstract class TwiML {
             this.children.add(new Text(text));
             return (T)this;
         }
+
+        /**
+         * @return TwiML object
+         */
+        public T addChild(GenericNode node) {
+            this.children.add(node);
+            return(T)this;
+        }
+
+
     }
+
 }

--- a/src/main/java/com/twilio/twiml/TwiML.java
+++ b/src/main/java/com/twilio/twiml/TwiML.java
@@ -51,13 +51,10 @@ public abstract class TwiML {
      *
      * @return A Map of attribute keys to values
      */
-    protected Map<String,String> getElementAttributes() {
+    protected Map<String, String> getElementAttributes() {
         return new HashMap<>();
     }
 
-    public Builder getBuilder() {
-        return this.builder;
-    }
     /**
      * Get tag name of this TwiML Element.
      */
@@ -214,7 +211,7 @@ public abstract class TwiML {
          */
         public T addChild(GenericNode node) {
             this.children.add(node);
-            return(T)this;
+            return (T)this;
         }
 
 

--- a/src/test/java/com/twilio/twiml/FaxResponseTest.java
+++ b/src/test/java/com/twilio/twiml/FaxResponseTest.java
@@ -87,8 +87,8 @@ public class FaxResponseTest {
         GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag").addText("Some text");
         GenericNode node = genericBuilder.build();
 
-        MessagingResponse.Builder builder = new MessagingResponse.Builder();
-        MessagingResponse elem = builder.addChild(node).build();
+        FaxResponse.Builder builder = new FaxResponse.Builder();
+        FaxResponse elem = builder.addChild(node).build();
 
         Assert.assertEquals(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +

--- a/src/test/java/com/twilio/twiml/FaxResponseTest.java
+++ b/src/test/java/com/twilio/twiml/FaxResponseTest.java
@@ -84,48 +84,38 @@ public class FaxResponseTest {
 
     @Test
     public void testElementWithGenericNode() {
-        FaxResponse.Builder builder = new FaxResponse.Builder();
-
-        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
-
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag").addText("Some text");
         GenericNode node = genericBuilder.build();
 
-        FaxResponse elem = builder.addChild(node).build();
+        MessagingResponse.Builder builder = new MessagingResponse.Builder();
+        MessagingResponse elem = builder.addChild(node).build();
 
         Assert.assertEquals(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<Response>" +
-                        "<genericTag/>"+
-                        "</Response>",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<Response>" +
+                "<genericTag>" +
+                "Some text" +
+                "</genericTag>" +
+                "</Response>",
                 elem.toXml()
         );
     }
 
     @Test
     public void testElementWithGenericNodeAttributes() {
-        FaxResponse.Builder builder = new FaxResponse.Builder();
-
         GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
+        GenericNode node = genericBuilder.option("key", "value").addText("someText").build();
 
-        genericBuilder.option("key", "value").addText("someText");
-
-        GenericNode node = genericBuilder.build();
-
-        Receive.Builder receiveBuilder = new Receive.Builder().addChild(node);
-
-        Receive message = receiveBuilder.build();
-
-        FaxResponse elem = builder.receive(message).build();
+        FaxResponse.Builder builder = new FaxResponse.Builder();
+        FaxResponse elem = builder.addChild(node).build();
 
         Assert.assertEquals(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<Response>" +
-                        "<Receive>"+
-                        "<genericTag key=\"value\">"+
-                        "someText"+
-                        "</genericTag>"+
-                        "</Receive>"+
-                        "</Response>",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<Response>" +
+                "<genericTag key=\"value\">" +
+                "someText" +
+                "</genericTag>" +
+                "</Response>",
                 elem.toXml()
         );
     }

--- a/src/test/java/com/twilio/twiml/FaxResponseTest.java
+++ b/src/test/java/com/twilio/twiml/FaxResponseTest.java
@@ -80,4 +80,53 @@ public class FaxResponseTest {
             elem.toXml()
         );
     }
+
+
+    @Test
+    public void testElementWithGenericNode() {
+        FaxResponse.Builder builder = new FaxResponse.Builder();
+
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
+
+        GenericNode node = genericBuilder.build();
+
+        FaxResponse elem = builder.addChild(node).build();
+
+        Assert.assertEquals(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        "<Response>" +
+                        "<genericTag/>"+
+                        "</Response>",
+                elem.toXml()
+        );
+    }
+
+    @Test
+    public void testElementWithGenericNodeAttributes() {
+        FaxResponse.Builder builder = new FaxResponse.Builder();
+
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
+
+        genericBuilder.option("key", "value").addText("someText");
+
+        GenericNode node = genericBuilder.build();
+
+        Receive.Builder receiveBuilder = new Receive.Builder().addChild(node);
+
+        Receive message = receiveBuilder.build();
+
+        FaxResponse elem = builder.receive(message).build();
+
+        Assert.assertEquals(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        "<Response>" +
+                        "<Receive>"+
+                        "<genericTag key=\"value\">"+
+                        "someText"+
+                        "</genericTag>"+
+                        "</Receive>"+
+                        "</Response>",
+                elem.toXml()
+        );
+    }
 }

--- a/src/test/java/com/twilio/twiml/MessagingResponseTest.java
+++ b/src/test/java/com/twilio/twiml/MessagingResponseTest.java
@@ -90,4 +90,50 @@ public class MessagingResponseTest {
             elem.toXml()
         );
     }
+
+    @Test
+    public void testElementWithGenericNode() {
+        MessagingResponse.Builder builder = new MessagingResponse.Builder();
+
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
+
+        GenericNode node = genericBuilder.build();
+
+        MessagingResponse elem = builder.addChild(node).build();
+
+        Assert.assertEquals(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        "<Response>" +
+                        "<genericTag/>"+
+                        "</Response>",
+                elem.toXml()
+        );
+    }
+
+    @Test
+    public void testElementWithGenericNodeAttributes() {
+        MessagingResponse.Builder builder = new MessagingResponse.Builder();
+
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
+        genericBuilder.option("key", "value").addText("someText");
+        GenericNode node = genericBuilder.build();
+
+        Message.Builder messageBuilder = new Message.Builder().addChild(node);
+
+        Message message = messageBuilder.build();
+
+        MessagingResponse elem = builder.message(message).build();
+
+        Assert.assertEquals(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        "<Response>" +
+                        "<Message>"+
+                        "<genericTag key=\"value\">"+
+                        "someText"+
+                        "</genericTag>"+
+                        "</Message>"+
+                        "</Response>",
+                elem.toXml()
+        );
+    }
 }

--- a/src/test/java/com/twilio/twiml/MessagingResponseTest.java
+++ b/src/test/java/com/twilio/twiml/MessagingResponseTest.java
@@ -93,46 +93,38 @@ public class MessagingResponseTest {
 
     @Test
     public void testElementWithGenericNode() {
-        MessagingResponse.Builder builder = new MessagingResponse.Builder();
-
-        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
-
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag").addText("Some text");
         GenericNode node = genericBuilder.build();
 
+        MessagingResponse.Builder builder = new MessagingResponse.Builder();
         MessagingResponse elem = builder.addChild(node).build();
 
         Assert.assertEquals(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<Response>" +
-                        "<genericTag/>"+
-                        "</Response>",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<Response>" +
+                "<genericTag>" +
+                "Some text" +
+                "</genericTag>" +
+                "</Response>",
                 elem.toXml()
         );
     }
 
     @Test
     public void testElementWithGenericNodeAttributes() {
-        MessagingResponse.Builder builder = new MessagingResponse.Builder();
-
         GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
-        genericBuilder.option("key", "value").addText("someText");
-        GenericNode node = genericBuilder.build();
+        GenericNode node = genericBuilder.option("key", "value").addText("someText").build();
 
-        Message.Builder messageBuilder = new Message.Builder().addChild(node);
-
-        Message message = messageBuilder.build();
-
-        MessagingResponse elem = builder.message(message).build();
+        MessagingResponse.Builder builder = new MessagingResponse.Builder();
+        MessagingResponse elem = builder.addChild(node).build();
 
         Assert.assertEquals(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<Response>" +
-                        "<Message>"+
-                        "<genericTag key=\"value\">"+
-                        "someText"+
-                        "</genericTag>"+
-                        "</Message>"+
-                        "</Response>",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<Response>" +
+                "<genericTag key=\"value\">" +
+                "someText" +
+                "</genericTag>" +
+                "</Response>",
                 elem.toXml()
         );
     }

--- a/src/test/java/com/twilio/twiml/VoiceResponseTest.java
+++ b/src/test/java/com/twilio/twiml/VoiceResponseTest.java
@@ -195,42 +195,38 @@ public class VoiceResponseTest {
 
     @Test
     public void testElementWithGenericNode() {
-        VoiceResponse.Builder builder = new VoiceResponse.Builder();
-
-        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
-
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag").addText("Some text");
         GenericNode node = genericBuilder.build();
 
+        VoiceResponse.Builder builder = new VoiceResponse.Builder();
         VoiceResponse elem = builder.addChild(node).build();
 
         Assert.assertEquals(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<Response>" +
-                        "<genericTag/>"+
-                        "</Response>",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<Response>" +
+                "<genericTag>" +
+                "Some text" +
+                "</genericTag>" +
+                "</Response>",
                 elem.toXml()
         );
     }
 
     @Test
     public void testElementWithGenericNodeAttributes() {
-        VoiceResponse.Builder builder = new VoiceResponse.Builder();
-
         GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
+        GenericNode node = genericBuilder.option("key", "value").addText("someText").build();
 
-        genericBuilder.option("key", "value").addText("someText");
-
-        GenericNode node = genericBuilder.build();
-
+        VoiceResponse.Builder builder = new VoiceResponse.Builder();
         VoiceResponse elem = builder.addChild(node).build();
 
         Assert.assertEquals(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                        "<Response>" +
-                        "<genericTag key=\"value\">" +
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<Response>" +
+                "<genericTag key=\"value\">" +
                 "someText" +
-                        "</genericTag>" +
-                        "</Response>",
+                "</genericTag>" +
+                "</Response>",
                 elem.toXml()
         );
     }

--- a/src/test/java/com/twilio/twiml/VoiceResponseTest.java
+++ b/src/test/java/com/twilio/twiml/VoiceResponseTest.java
@@ -192,4 +192,46 @@ public class VoiceResponseTest {
             elem.toXml()
         );
     }
+
+    @Test
+    public void testElementWithGenericNode() {
+        VoiceResponse.Builder builder = new VoiceResponse.Builder();
+
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
+
+        GenericNode node = genericBuilder.build();
+
+        VoiceResponse elem = builder.addChild(node).build();
+
+        Assert.assertEquals(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        "<Response>" +
+                        "<genericTag/>"+
+                        "</Response>",
+                elem.toXml()
+        );
+    }
+
+    @Test
+    public void testElementWithGenericNodeAttributes() {
+        VoiceResponse.Builder builder = new VoiceResponse.Builder();
+
+        GenericNode.Builder genericBuilder = new GenericNode.Builder("genericTag");
+
+        genericBuilder.option("key", "value").addText("someText");
+
+        GenericNode node = genericBuilder.build();
+
+        VoiceResponse elem = builder.addChild(node).build();
+
+        Assert.assertEquals(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        "<Response>" +
+                        "<genericTag key=\"value\">" +
+                "someText" +
+                        "</genericTag>" +
+                        "</Response>",
+                elem.toXml()
+        );
+    }
 }


### PR DESCRIPTION
- Allow specifying name for a TwiML node

- Add tests for `MessagingResponse`, `VoiceResponse` and `FaxResponse`

Note: tests are auto-generated; will make a separate PR for the code generation.
