### PR TITLE
Add a method for validation of JSON body

### DIFF
--- a/src/main/java/com/twilio/security/RequestValidator.java
+++ b/src/main/java/com/twilio/security/RequestValidator.java
@@ -2,14 +2,20 @@ package com.twilio.security;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,8 +34,23 @@ public class RequestValidator {
         return secureCompare(signature, expectedSignature);
     }
 
-    public boolean validate(String url, Map<String, String> params, String body, String expectedSignature) {
-        return validate(url, params, expectedSignature) && validateBody(body, params.get("bodySHA256"));
+    public boolean validate(String url, String body, String expectedSignature) throws URISyntaxException {
+        Map<String, String> empty = new HashMap<String, String>();
+        List<NameValuePair> params = URLEncodedUtils.parse(new URI(url), StandardCharsets.UTF_8.toString());
+
+        NameValuePair bodySHA256 = null;
+        for (NameValuePair param : params) {
+            if (param.getName().equals("bodySHA256")) {
+                bodySHA256 = param;
+                break;
+            }
+        }
+
+        if (bodySHA256 != null) {
+            return validate(url, empty, expectedSignature) && validateBody(body, bodySHA256.getValue());
+        } else {
+            return false;
+        }
     }
 
     public boolean validateBody(String body, String expectedSHA) {

--- a/src/test/java/com/twilio/security/RequestValidatorTest.java
+++ b/src/test/java/com/twilio/security/RequestValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,20 +12,21 @@ import java.util.Map;
  * Test class for {@link RequestValidator}.
  */
 public class RequestValidatorTest {
-    Map<String, String> params = new HashMap<>();
-    String url = "https://mycompany.com/myapp.php?foo=1&bar=2";
-    RequestValidator validator = new RequestValidator("12345");
-    String signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
-    String body = "{\"property\": \"value\", \"boolean\": true}";
-    String bodySignature = "Ch/3Y02as7ldtcmi3+lBbkFQKyg6gMfPGWMmMvluZiA=";
+    private Map<String, String> params = new HashMap<>();
+    private String url = "https://mycompany.com/myapp.php?foo=1&bar=2";
+    private RequestValidator validator = new RequestValidator("12345");
+    private String signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
+    private String body = "{\"property\": \"value\", \"boolean\": true}";
+    private String bodyHash = "Ch/3Y02as7ldtcmi3+lBbkFQKyg6gMfPGWMmMvluZiA=";
+    private String bodyHashEncoded = bodyHash.replace("+", "%2B").replace("=", "%3D");
 
     @Before
     public void setUp() {
-        params.put("CallSid", "CA1234567890ABCDE");
-        params.put("Caller", "+14158675309");
         params.put("Digits", "1234");
-        params.put("From", "+14158675309");
+        params.put("CallSid", "CA1234567890ABCDE");
         params.put("To", "+18005551212");
+        params.put("Caller", "+14158675309");
+        params.put("From", "+14158675309");
     }
 
     @Test
@@ -42,7 +44,7 @@ public class RequestValidatorTest {
 
     @Test
     public void testValidateBody() {
-        boolean isValid = validator.validateBody(body, bodySignature);
+        boolean isValid = validator.validateBody(body, bodyHash);
 
         Assert.assertTrue("Body validation failed", isValid);
     }
@@ -55,18 +57,26 @@ public class RequestValidatorTest {
     }
 
     @Test
-    public void testValidateWithBody() {
-        params.put("bodySHA256", bodySignature);
-        signature = "lhN9sMASXtkij921mMLP/O8yo04=";
-
-        boolean isValid = validator.validate(url, params, body, signature);
+    public void testValidateWithBody() throws URISyntaxException {
+        String url = this.url + "&bodySHA256=" + bodyHashEncoded;
+        String signatureWithHash = "afcFvPLPYT8mg/JyIVkdnqQKa2s=";
+        boolean isValid = validator.validate(url, body, signatureWithHash);
 
         Assert.assertTrue("Body validation failed", isValid);
     }
 
     @Test
-    public void testValidateBodyWithoutSignature() {
-        boolean isValid = validator.validate(url, params, body, signature);
+    public void testValidateWithNoOtherParameters() throws URISyntaxException {
+        String url = "https://mycompany.com/myapp.php?bodySHA256=" + bodyHashEncoded;
+        String signatureWithHash = "DXnNFCj8DJ/hZmiSg4UzaDHw5Og=";
+        boolean isValid = validator.validate(url, body, signatureWithHash);
+
+        Assert.assertTrue("Body validation failed", isValid);
+    }
+
+    @Test
+    public void testValidateBodyWithoutSignature() throws URISyntaxException {
+        boolean isValid = validator.validate(url, body, signature);
 
         Assert.assertFalse("Validation should have failed with no bodySHA256", isValid);
     }

--- a/src/test/java/com/twilio/security/RequestValidatorTest.java
+++ b/src/test/java/com/twilio/security/RequestValidatorTest.java
@@ -14,7 +14,7 @@ public class RequestValidatorTest {
     Map<String, String> params = new HashMap<>();
     String url = "https://mycompany.com/myapp.php?foo=1&bar=2";
     RequestValidator validator = new RequestValidator("12345");
-    String signature;
+    String signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
     String body = "{\"property\": \"value\", \"boolean\": true}";
     String bodySignature = "Ch/3Y02as7ldtcmi3+lBbkFQKyg6gMfPGWMmMvluZiA=";
 
@@ -25,8 +25,6 @@ public class RequestValidatorTest {
         params.put("Digits", "1234");
         params.put("From", "+14158675309");
         params.put("To", "+18005551212");
-
-        signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
     }
 
     @Test

--- a/src/test/java/com/twilio/security/RequestValidatorTest.java
+++ b/src/test/java/com/twilio/security/RequestValidatorTest.java
@@ -1,6 +1,7 @@
 package com.twilio.security;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -10,23 +11,66 @@ import java.util.Map;
  * Test class for {@link RequestValidator}.
  */
 public class RequestValidatorTest {
+    Map<String, String> params = new HashMap<>();
+    String url = "https://mycompany.com/myapp.php?foo=1&bar=2";
+    RequestValidator validator = new RequestValidator("12345");
+    String signature;
+    String body = "{\"property\": \"value\", \"boolean\": true}";
+    String bodySignature = "Ch/3Y02as7ldtcmi3+lBbkFQKyg6gMfPGWMmMvluZiA=";
 
-    @Test
-    public void testValidate() {
-
-        RequestValidator validator = new RequestValidator("12345");
-
-        String url = "https://mycompany.com/myapp.php?foo=1&bar=2";
-        Map<String, String> params = new HashMap<>();
+    @Before
+    public void setUp() {
         params.put("CallSid", "CA1234567890ABCDE");
         params.put("Caller", "+14158675309");
         params.put("Digits", "1234");
         params.put("From", "+14158675309");
         params.put("To", "+18005551212");
 
-        String signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
+        signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
+    }
 
+    @Test
+    public void testValidate() {
         Assert.assertTrue("Request does not match provided signature", validator.validate(url, params, signature));
+    }
+
+    @Test
+    public void testFailsWhenIncorrect() {
+        signature = "NOTRSOYDt4T1cUTdK1PDd93/VVr8B8=";
+        boolean isValid = validator.validate(url, params, signature);
+
+        Assert.assertFalse("Request should have failed validation, but didn't", isValid);
+    }
+
+    @Test
+    public void testValidateBody() {
+        boolean isValid = validator.validateBody(body, bodySignature);
+
+        Assert.assertTrue("Body validation failed", isValid);
+    }
+
+    @Test
+    public void testValidateBodyFailsWhenWrong() {
+        boolean isValid = validator.validateBody(body, "WRONG");
+
+        Assert.assertFalse("Body validation should have failed, but didn't", isValid);
+    }
+
+    @Test
+    public void testValidateWithBody() {
+        params.put("bodySHA256", bodySignature);
+        signature = "lhN9sMASXtkij921mMLP/O8yo04=";
+
+        boolean isValid = validator.validate(url, params, body, signature);
+
+        Assert.assertTrue("Body validation failed", isValid);
+    }
+
+    @Test
+    public void testValidateBodyWithoutSignature() {
+        boolean isValid = validator.validate(url, params, body, signature);
+
+        Assert.assertFalse("Validation should have failed with no bodySHA256", isValid);
     }
 
 }


### PR DESCRIPTION
If we want to validate requests that have a POST body payload, this allows us to compare it against the `bodySHA256` parameter that will be sent from the Twilio Webhook.