### PR TITLE
Tag and push Docker latest image when deploying with TravisCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,10 @@ docker-build:
 	docker build -t twilio/twilio-java .
 	docker tag twilio/twilio-java twilio/twilio-java:${TRAVIS_TAG}
 	docker tag twilio/twilio-java twilio/twilio-java:apidefs-${API_DEFINITIONS_SHA}
+	docker tag twilio/twilio-java twilio/twilio-java:latest
 
 docker-push:
 	echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 	docker push twilio/twilio-java:${TRAVIS_TAG}
 	docker push twilio/twilio-java:apidefs-${API_DEFINITIONS_SHA}
+	docker push twilio/twilio-java:latest


### PR DESCRIPTION
Necessary image tag to be used with Tricorder.