### PR TITLE
Update Response to use Scanner hasNext()

### DIFF
--- a/src/main/java/com/twilio/http/Response.java
+++ b/src/main/java/com/twilio/http/Response.java
@@ -1,6 +1,5 @@
 package com.twilio.http;
 
-import com.twilio.exception.ApiConnectionException;
 import com.twilio.exception.ApiException;
 
 import java.io.ByteArrayInputStream;
@@ -53,21 +52,21 @@ public class Response {
         if (content != null) {
             return content;
         }
-        // XXX we probably don't need this and should convert strings into
-        // streams in the mock scaffolding
-        try {
-            if (stream.available() == 0) {
+
+        if (stream != null) {
+            Scanner scanner = new Scanner(stream, "UTF-8").useDelimiter("\\A");
+
+            if (!scanner.hasNext()) {
                 return "";
             }
-        } catch (final IOException e) {
-            throw new ApiConnectionException("IOException during API request to Twilio", e);
+
+            String data = scanner.next();
+            scanner.close();
+
+            return data;
         }
 
-        Scanner scanner = new Scanner(stream, "UTF-8").useDelimiter("\\A");
-        String data = scanner.next();
-        scanner.close();
-
-        return data;
+        return "";
     }
 
     /**


### PR DESCRIPTION
Since some stream implementations return 0 for `available()` even though there is more data (since it's non-blocking), this instead uses Scanner's `hasNext` method to check if there is additional data that we could expect (which is blocking, as expected).