### PR TITLE
Clone the headers object and add test for thread safety

### DIFF
--- a/src/main/java/com/twilio/http/ValidationInterceptor.java
+++ b/src/main/java/com/twilio/http/ValidationInterceptor.java
@@ -23,7 +23,7 @@ public class ValidationInterceptor implements HttpRequestInterceptor {
 
     /**
      * Create a new ValidationInterceptor.
-     * 
+     *
      * @param  accountSid Twilio Acocunt SID
      * @param  credentialSid Twilio Credential SID
      * @param  signingKeySid Twilio Signing Key
@@ -39,11 +39,11 @@ public class ValidationInterceptor implements HttpRequestInterceptor {
     @Override
     public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
         Jwt jwt = ValidationToken.fromHttpRequest(
-            accountSid, 
-            credentialSid, 
-            signingKeySid, 
-            privateKey, 
-            request, 
+            accountSid,
+            credentialSid,
+            signingKeySid,
+            privateKey,
+            request,
             HEADERS
         );
         request.addHeader("Twilio-Client-Validation", jwt.toJwt());

--- a/src/main/java/com/twilio/jwt/validation/ValidationToken.java
+++ b/src/main/java/com/twilio/jwt/validation/ValidationToken.java
@@ -18,6 +18,7 @@ import org.apache.http.HttpRequest;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.security.PrivateKey;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -92,14 +93,14 @@ public class ValidationToken extends Jwt {
 
     /**
      * Create a ValidationToken from an HTTP Request.
-     * 
+     *
      * @param  accountSid Twilio Account SID
      * @param  credentialSid Twilio Credential SID
      * @param  signingKeySid Twilio Signing Key SID
      * @param  privateKey Private Key
      * @param  request HTTP Request
      * @param  signedHeaders Headers to sign
-     * 
+     *
      * @throws IOException when unable to generate
      * @return The ValidationToken generated from the HttpRequest
      */
@@ -159,7 +160,7 @@ public class ValidationToken extends Jwt {
 
         /**
          * Create a new ValidationToken Builder.
-         * 
+         *
          * @param  accountSid Twilio Account SID
          * @param  credentialSid Twilio Crednetial SID
          * @param  signingKeySid Twilio Signing Key SID
@@ -193,7 +194,7 @@ public class ValidationToken extends Jwt {
         }
 
         public Builder signedHeaders(List<String> signedHeaders) {
-            this.signedHeaders = signedHeaders;
+            this.signedHeaders = new ArrayList<>(signedHeaders);
             return this;
         }
 

--- a/src/main/java/com/twilio/jwt/validation/ValidationToken.java
+++ b/src/main/java/com/twilio/jwt/validation/ValidationToken.java
@@ -18,12 +18,7 @@ import org.apache.http.HttpRequest;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.security.PrivateKey;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 
 public class ValidationToken extends Jwt {
@@ -194,7 +189,12 @@ public class ValidationToken extends Jwt {
         }
 
         public Builder signedHeaders(List<String> signedHeaders) {
-            this.signedHeaders = new ArrayList<>(signedHeaders);
+            if (signedHeaders == null) {
+                this.signedHeaders = Collections.emptyList();
+            } else {
+                this.signedHeaders = new ArrayList<>(signedHeaders);
+            }
+
             return this;
         }
 


### PR DESCRIPTION
Previously, this library was doing direct modification of the headers object passed to `ValidationToken.fromHttpRequest`.

This change instead clones that object so we can do with it what we desire.

Additionally, this adds a test for thread safety of the `ValidationInterceptor#process` method call. This test correctly failed before the modifications to `ValidationInterceptor.java` were made.