### PR TITLE
Upgrade jackson library to 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
   </profiles>
 
   <properties>
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <skip.tests>false</skip.tests>
   </properties>
 


### PR DESCRIPTION
- Bump `jackson` library version to 2.9.8 due to vulnerabilities in `jackson-databind` versions >= 2.9.0 and < 2.9.8