### PR TITLE
Add [archunit] rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,12 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <version>0.10.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/com/twilio/compliance/ComplianceTest.java
+++ b/src/test/java/com/twilio/compliance/ComplianceTest.java
@@ -1,0 +1,38 @@
+package com.twilio.compliance;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.ImportOptions;
+import com.tngtech.archunit.lang.syntax.elements.GivenClassesConjunction;
+import static com.tngtech.archunit.library.GeneralCodingRules.*;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ComplianceTest {
+    static final private ImportOptions importOpts = new ImportOptions().with(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS);
+    static final private JavaClasses twilioClasses = new ClassFileImporter(importOpts).importPackages("com.twilio");
+
+    @Before
+    public void setUp() {
+        assertTrue(twilioClasses.size() > 0);
+    }
+
+    @Test
+    public void noClassesShouldUseJavaUtilLogging() {
+        NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING.check(twilioClasses);
+    }
+
+    @Test
+    public void resourceClassSanityCheck() {
+        GivenClassesConjunction resourceClasses = classes().that().areAssignableTo(com.twilio.base.Resource.class).and().doNotHaveFullyQualifiedName(com.twilio.base.Resource.class.getName());
+
+        resourceClasses.should()
+            .beAnnotatedWith(com.fasterxml.jackson.annotation.JsonIgnoreProperties.class)
+            .andShould()
+            .haveOnlyFinalFields()
+            .check(twilioClasses);
+    }
+}


### PR DESCRIPTION
- enforce consistency across all Resource subclasses
- block [java.util.logging] usage

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
