### PR TITLE
Replace commons codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,15 +284,16 @@
           <xmlOutput>true</xmlOutput>
           <failOnError>false</failOnError>
         </configuration>
-        <executions>
-          <execution>
-            <id>analyse-compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
+        <!-- Slows down feedback cycle, maybe add to compile phase later? -->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>analyse-compile</id>-->
+<!--            <phase>compile</phase>-->
+<!--            <goals>-->
+<!--              <goal>check</goal>-->
+<!--            </goals>-->
+<!--          </execution>-->
+<!--        </executions>-->
       </plugin>
 
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,29 @@
         </configuration>
       </plugin>
 
+      <!-- Run spotbugs separately: mvn spotbugs:check -->
+      <!-- To view results via gui: mvn spotbugs:gui -->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.1.12</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+          <xmlOutput>true</xmlOutput>
+          <failOnError>false</failOnError>
+        </configuration>
+        <executions>
+          <execution>
+            <id>analyse-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/twilio/example/ValidationExample.java
+++ b/src/main/java/com/twilio/example/ValidationExample.java
@@ -9,9 +9,9 @@ import com.twilio.rest.api.v2010.account.NewSigningKey;
 import com.twilio.twiml.TwiMLException;
 import com.twilio.type.PhoneNumber;
 
+import javax.xml.bind.DatatypeConverter;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.util.Base64;
 
 public class ValidationExample {
 
@@ -39,7 +39,7 @@ public class ValidationExample {
 
         // Create a public key and signing key using the default client
         PublicKey key = PublicKey.creator(
-            Base64.getEncoder().encodeToString(pk.getEncoded())
+            DatatypeConverter.printBase64Binary(pk.getEncoded())
         ).setFriendlyName("Public Key").create(client);
 
         NewSigningKey signingKey = NewSigningKey.creator().create(client);

--- a/src/main/java/com/twilio/example/ValidationExample.java
+++ b/src/main/java/com/twilio/example/ValidationExample.java
@@ -8,10 +8,10 @@ import com.twilio.rest.api.v2010.account.Message;
 import com.twilio.rest.api.v2010.account.NewSigningKey;
 import com.twilio.twiml.TwiMLException;
 import com.twilio.type.PhoneNumber;
-import org.apache.commons.codec.binary.Base64;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.util.Base64;
 
 public class ValidationExample {
 
@@ -39,7 +39,7 @@ public class ValidationExample {
 
         // Create a public key and signing key using the default client
         PublicKey key = PublicKey.creator(
-            Base64.encodeBase64String(pk.getEncoded())
+            Base64.getEncoder().encodeToString(pk.getEncoded())
         ).setFriendlyName("Public Key").create(client);
 
         NewSigningKey signingKey = NewSigningKey.creator().create(client);

--- a/src/main/java/com/twilio/http/Request.java
+++ b/src/main/java/com/twilio/http/Request.java
@@ -7,6 +7,7 @@ import com.twilio.exception.InvalidRequestException;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
+import javax.xml.bind.DatatypeConverter;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -93,7 +94,7 @@ public class Request {
         String credentials = this.username + ":" + this.password;
         try {
 
-            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes("ascii"));
+            String encoded = DatatypeConverter.printBase64Binary(credentials.getBytes("ascii"));
             return "Basic " + encoded;
 
         } catch (final UnsupportedEncodingException e) {

--- a/src/main/java/com/twilio/http/Request.java
+++ b/src/main/java/com/twilio/http/Request.java
@@ -4,7 +4,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Range;
 import com.twilio.exception.ApiException;
 import com.twilio.exception.InvalidRequestException;
-import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -14,11 +13,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 public class Request {
 
@@ -98,7 +93,7 @@ public class Request {
         String credentials = this.username + ":" + this.password;
         try {
 
-            String encoded = new Base64().encodeAsString(credentials.getBytes("ascii"));
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes("ascii"));
             return "Basic " + encoded;
 
         } catch (final UnsupportedEncodingException e) {

--- a/src/main/java/com/twilio/security/RequestValidator.java
+++ b/src/main/java/com/twilio/security/RequestValidator.java
@@ -83,7 +83,7 @@ public class RequestValidator {
             mac.init(signingKey);
 
             byte[] rawHmac = mac.doFinal(builder.toString().getBytes(StandardCharsets.UTF_8));
-            return new String(Base64.getEncoder().encode(rawHmac));
+            return DatatypeConverter.printBase64Binary(rawHmac);
 
         } catch (Exception e) {
             return null;

--- a/src/main/java/com/twilio/security/RequestValidator.java
+++ b/src/main/java/com/twilio/security/RequestValidator.java
@@ -1,13 +1,11 @@
 package com.twilio.security;
 
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import javax.xml.bind.DatatypeConverter;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -15,11 +13,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class RequestValidator {
 
@@ -58,13 +52,13 @@ public class RequestValidator {
     public boolean validateBody(String body, String expectedSHA) {
         MessageDigest digest;
         try {
-            digest = MessageDigest.getInstance(MessageDigestAlgorithms.SHA_256);
+            digest = MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {
             return false;
         }
 
         byte[] hash = digest.digest(body.getBytes(StandardCharsets.UTF_8));
-        String hexString = new String(Hex.encodeHex(hash));
+        String hexString = DatatypeConverter.printHexBinary(hash).toLowerCase();
 
         return secureCompare(expectedSHA, hexString);
     }
@@ -89,7 +83,7 @@ public class RequestValidator {
             mac.init(signingKey);
 
             byte[] rawHmac = mac.doFinal(builder.toString().getBytes(StandardCharsets.UTF_8));
-            return new String(Base64.encodeBase64(rawHmac));
+            return new String(Base64.getEncoder().encode(rawHmac));
 
         } catch (Exception e) {
             return null;


### PR DESCRIPTION
Hi,

At work, we use your twilio library to send sms messages.  We use Sonatype vulnerability scanner to scan our code base for security vulnerabilities.  Apache commons codec was picked up with issues for Base64, BCodec, Base32 classes.  There's no CVE (Common Vulnerabilities and Exposures), but Sonatype raised an internal issue referencing apache issue below.

https://issues.apache.org/jira/browse/CODEC-134

The fix was to use java util Base64 encoder and remove apache commons codec dependency.  Maven tests passed.

I also added Spotbugs scan to the compile phase to highlight potential issues, which doesn't fail the build on error.  You can kick it off independently using 'mvn spotbugs:check'.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
