### PR TITLE
Catch NPE when creating URI

### DIFF
--- a/src/main/java/com/twilio/converter/Promoter.java
+++ b/src/main/java/com/twilio/converter/Promoter.java
@@ -18,7 +18,7 @@ public class Promoter {
     public static URI uriFromString(final String url) {
         try {
             return new URI(url);
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | NullPointerException e) {
             return null;
         }
     }


### PR DESCRIPTION
This PR catches an NPE that is thrown when passing in a `null` url to `MessageCreator.setMediaUrl()`.

A few reasons it makes sense to do this:

1. `MessageCreator.create()` itself handles `null` values for any params:
https://github.com/twilio/twilio-java/blob/ce1c4512efde5cd9ca6c70dc9432efa5459ce48e/src/main/java/com/twilio/rest/api/v2010/account/MessageCreator.java#L501
2. Checking for a `null` mediaUrl string messes up the flow using the API:
```
    Message message = Message.creator(toPN, fromPN, body)
            .setMediaUrl(mediaUrl)	
            .create();
```
turns into this:
```
    MessageCreator messageCreator = Message.creator(toPN, fromPN, body);

    if (!Strings.isNullOrEmpty(mediaUrl)) {
      messageCreator.setMediaUrl(mediaUrl);
    }

    Message message = messageCreator.create();
```

3. We are already returning null if we throw a `URISyntaxException`.

https://github.com/twilio/twilio-java/blob/ce1c4512efde5cd9ca6c70dc9432efa5459ce48e/src/main/java/com/twilio/converter/Promoter.java#L21
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
