### PR TITLE
VIDEO-2338 TrackPriority.STANDARD before GA

### DIFF
--- a/src/main/java/com/twilio/type/SubscribeRule.java
+++ b/src/main/java/com/twilio/type/SubscribeRule.java
@@ -75,7 +75,7 @@ public class SubscribeRule {
 
     public enum Priority {
         LOW("low"),
-        MEDIUM("medium"),
+        STANDARD("standard"),
         HIGH("high");
 
         private final String value;

--- a/src/test/java/com/twilio/type/SubscribeRuleTest.java
+++ b/src/test/java/com/twilio/type/SubscribeRuleTest.java
@@ -51,14 +51,14 @@ public class SubscribeRuleTest extends TypeTest {
                 "    \"track\": \"screen\",\n" +
                 "    \"kind\": \"video\",\n" +
                 "    \"publisher\": \"alice\",\n" +
-                "    \"priority\": \"medium\"\n" +
+                "    \"priority\": \"standard\"\n" +
                 "}";
 
         SubscribeRule r = fromJson(json, SubscribeRule.class);
         Assert.assertEquals(SubscribeRule.Type.EXCLUDE, r.getType());
         Assert.assertEquals(SubscribeRule.Kind.VIDEO, r.getKind());
         Assert.assertEquals("alice", r.getPublisher());
-        Assert.assertEquals(SubscribeRule.Priority.MEDIUM, r.getPriority());
+        Assert.assertEquals(SubscribeRule.Priority.STANDARD, r.getPriority());
         Assert.assertNull(r.getAll());
 
         Assert.assertTrue(convertsToAndFromJson(r, SubscribeRule.class));


### PR DESCRIPTION
Before GA of the Bandwidth Profile API, we have decided to change the TrackPriority to `STANDARD` as this more accurately describes the priority we're using.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
