### PR TITLE
fix: shut down executorService thread automatically to allow the JVM to shut down gracefully

### DIFF
--- a/src/main/java/com/twilio/Twilio.java
+++ b/src/main/java/com/twilio/Twilio.java
@@ -31,6 +31,19 @@ public class Twilio {
     private Twilio() {}
 
     /**
+     * Ensures that the ListeningExecutorService is shutdown when the JVM exits.
+     */
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                if (executorService != null) {
+                    executorService.shutdownNow();
+                }
+            }
+        });
+    }
+
+    /**
      * Initialize the Twilio environment.
      *
      * @param username account to use
@@ -57,8 +70,8 @@ public class Twilio {
     /**
      * Set the username.
      *
-     * @param username account sid to use
-     * @throws AuthenticationException if accountSid is null
+     * @param username account to use
+     * @throws AuthenticationException if username is null
      */
     public static void setUsername(final String username) {
         if (username == null) {
@@ -158,7 +171,7 @@ public class Twilio {
      *
      * @param executorService executor service to use
      */
-    public static void setExecutorService(final ListeningExecutorService executorService) {
+    public static synchronized void setExecutorService(final ListeningExecutorService executorService) {
         Twilio.executorService = executorService;
     }
 
@@ -189,5 +202,14 @@ public class Twilio {
      */
     private static void invalidate() {
         Twilio.restClient = null;
+    }
+
+    /**
+     * Attempts to gracefully shutdown the ListeningExecutorService if it is present.
+     */
+    public static synchronized void destroy() {
+        if (executorService != null) {
+            executorService.shutdown();
+        }
     }
 }

--- a/src/test/java/com/twilio/TwilioTest.java
+++ b/src/test/java/com/twilio/TwilioTest.java
@@ -22,6 +22,7 @@ import mockit.NonStrictExpectations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class TwilioTest {
@@ -71,6 +72,15 @@ public class TwilioTest {
                 Executors.newCachedThreadPool());
         Twilio.setExecutorService(listeningExecutorService);
         assertEquals(listeningExecutorService, Twilio.getExecutorService());
+    }
+
+    @Test
+    public void testDestroyExecutorService() {
+        ListeningExecutorService listeningExecutorService = MoreExecutors.listeningDecorator(
+                Executors.newCachedThreadPool());
+        Twilio.setExecutorService(listeningExecutorService);
+        Twilio.destroy();
+        assertTrue(Twilio.getExecutorService().isShutdown());
     }
 
     @Test


### PR DESCRIPTION
Fixes #431 

Initial attempt at trying to mitigate some threading issues in the Twilio API. I'm a bit new to open source, but I think this should try and help (or at least pave the initial steps) for issue #431

I didn't quite see the reason why a `boolean` was necessary (as mentioned by @bohnman in #431). Regardless if the executor service is set by the user or if it is generated internally, we should shutdown the executor service anyway, am I right?

Oh, and I think there might have been a small typo in the `setUsername` method. I updated that as well.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
