### PR TITLE
fix: Do not include null values in JWT payloads

### DIFF
--- a/src/main/java/com/twilio/jwt/accesstoken/ChatGrant.java
+++ b/src/main/java/com/twilio/jwt/accesstoken/ChatGrant.java
@@ -1,13 +1,13 @@
 package com.twilio.jwt.accesstoken;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 /**
  * Grant used to access Twilio Chat.
  *
  * <p>
- *     For more information see:
- *     <a href="https://www.twilio.com/docs/api/rest/access-tokens">
- *         https://www.twilio.com/docs/api/rest/access-tokens
- *     </a>
+ * For more information see:
+ * <a href="https://www.twilio.com/docs/api/rest/access-tokens">
+ * https://www.twilio.com/docs/api/rest/access-tokens </a>
  * </p>
  */
 public class ChatGrant implements Grant {
@@ -63,6 +63,7 @@ public class ChatGrant implements Grant {
     }
 
     @SuppressWarnings("checkstyle:membername")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public class Payload {
         public final String service_sid;
         public final String deployment_role_sid;

--- a/src/main/java/com/twilio/jwt/accesstoken/ChatGrant.java
+++ b/src/main/java/com/twilio/jwt/accesstoken/ChatGrant.java
@@ -5,9 +5,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * Grant used to access Twilio Chat.
  *
  * <p>
- * For more information see:
- * <a href="https://www.twilio.com/docs/api/rest/access-tokens">
- * https://www.twilio.com/docs/api/rest/access-tokens </a>
+ *     For more information see:
+ *     <a href="https://www.twilio.com/docs/api/rest/access-tokens">
+ *         https://www.twilio.com/docs/api/rest/access-tokens
+ *     </a>
  * </p>
  */
 public class ChatGrant implements Grant {

--- a/src/main/java/com/twilio/jwt/accesstoken/ConversationsGrant.java
+++ b/src/main/java/com/twilio/jwt/accesstoken/ConversationsGrant.java
@@ -1,5 +1,7 @@
 package com.twilio.jwt.accesstoken;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Grant used to access Twilio Conversations.
  *
@@ -35,6 +37,7 @@ public class ConversationsGrant implements Grant {
 
 
     @SuppressWarnings("checkstyle:membername")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public class Payload {
         public final String configuration_profile_sid;
 

--- a/src/main/java/com/twilio/jwt/accesstoken/IpMessagingGrant.java
+++ b/src/main/java/com/twilio/jwt/accesstoken/IpMessagingGrant.java
@@ -1,5 +1,7 @@
 package com.twilio.jwt.accesstoken;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Grant used to access Twilio IP Messaging.
  *
@@ -64,6 +66,7 @@ public class IpMessagingGrant implements Grant {
     }
 
     @SuppressWarnings("checkstyle:membername")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public class Payload {
         public final String service_sid;
         public final String deployment_role_sid;

--- a/src/main/java/com/twilio/jwt/accesstoken/SyncGrant.java
+++ b/src/main/java/com/twilio/jwt/accesstoken/SyncGrant.java
@@ -1,5 +1,7 @@
 package com.twilio.jwt.accesstoken;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Grant used to access Twilio Sync.
  *
@@ -44,6 +46,7 @@ public class SyncGrant implements Grant {
     }
 
     @SuppressWarnings("checkstyle:membername")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public class Payload {
         public final String service_sid;
         public final String endpoint_id;

--- a/src/main/java/com/twilio/jwt/accesstoken/TaskRouterGrant.java
+++ b/src/main/java/com/twilio/jwt/accesstoken/TaskRouterGrant.java
@@ -1,5 +1,7 @@
 package com.twilio.jwt.accesstoken;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Grant used to access Twilio TaskRouter.
  *
@@ -54,6 +56,7 @@ public class TaskRouterGrant implements Grant {
     }
 
     @SuppressWarnings("checkstyle:membername")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public class Payload {
         public final String workspace_sid;
         public final String worker_sid;

--- a/src/main/java/com/twilio/jwt/accesstoken/VideoGrant.java
+++ b/src/main/java/com/twilio/jwt/accesstoken/VideoGrant.java
@@ -67,7 +67,7 @@ public class VideoGrant implements Grant {
 
 
     @SuppressWarnings("checkstyle:membername")
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public class Payload {
         public final String configuration_profile_sid;
         public final String room;

--- a/src/main/java/com/twilio/jwt/accesstoken/VoiceGrant.java
+++ b/src/main/java/com/twilio/jwt/accesstoken/VoiceGrant.java
@@ -1,5 +1,6 @@
 package com.twilio.jwt.accesstoken;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.base.Strings;
 
 import java.util.HashMap;
@@ -70,6 +71,7 @@ public class VoiceGrant implements Grant {
     }
 
     @SuppressWarnings("checkstyle:membername")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public class Payload {
         public Map<String, Object> incoming;
         public Map<String, Object> outgoing;

--- a/src/test/java/com/twilio/jwt/accesstoken/AccessTokenTest.java
+++ b/src/test/java/com/twilio/jwt/accesstoken/AccessTokenTest.java
@@ -1,5 +1,7 @@
 package com.twilio.jwt.accesstoken;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.jwt.Jwt;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -335,5 +337,19 @@ public class AccessTokenTest {
         Map<String, Object> outgoingParams = (Map<String, Object>) outgoing.get("params");
         Assert.assertEquals("AP123", outgoing.get("application_sid"));
         Assert.assertEquals("bar", outgoingParams.get("foo"));
+    }
+
+    @Test()
+    public void testNullValues() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        ChatGrant grant = new ChatGrant()
+            .setDeploymentRoleSid("RL123")
+            .setPushCredentialSid("CR123")
+            .setServiceSid("IS123");
+        String payload = mapper.writeValueAsString(grant);
+        Assert.assertFalse(payload.contains("endpoint_id"));
+        Assert.assertTrue(payload.contains("deployment_role_sid"));
+        Assert.assertTrue(payload.contains("push_credential_sid"));
+        Assert.assertTrue(payload.contains("service_sid"));
     }
 }

--- a/src/test/java/com/twilio/jwt/accesstoken/AccessTokenTest.java
+++ b/src/test/java/com/twilio/jwt/accesstoken/AccessTokenTest.java
@@ -1,7 +1,5 @@
 package com.twilio.jwt.accesstoken;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twilio.jwt.Jwt;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -33,6 +31,13 @@ public class AccessTokenTest {
         Assert.assertTrue(claims.getExpiration().getTime() > new Date().getTime());
     }
 
+    private Claims getClaimFromJwtToken(Jwt token) {
+        return Jwts.parser()
+                   .setSigningKey(SECRET.getBytes())
+                   .parseClaimsJws(token.toJwt())
+                   .getBody();
+    } 
+
     private void testVoiceToken(Boolean allow) {
         Map<String, Object> params = new HashMap<>();
         params.put("foo", "bar");
@@ -46,11 +51,7 @@ public class AccessTokenTest {
                 .grant(pvg)
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
         Map<String, Object> decodedGrants = (Map<String, Object>) claims.get("grants");
@@ -73,11 +74,7 @@ public class AccessTokenTest {
             new AccessToken.Builder(ACCOUNT_SID, SIGNING_KEY_SID, SECRET)
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
     }
@@ -90,11 +87,7 @@ public class AccessTokenTest {
                 .nbf(new Date())
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
         Assert.assertTrue(claims.getNotBefore().getTime() <= new Date().getTime());
@@ -108,11 +101,7 @@ public class AccessTokenTest {
                 .grant(cg)
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
 
@@ -131,11 +120,7 @@ public class AccessTokenTest {
                 .grant(cg)
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
 
@@ -158,11 +143,7 @@ public class AccessTokenTest {
                 .grant(ipg)
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
 
@@ -188,11 +169,7 @@ public class AccessTokenTest {
                 .grant(cg)
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
 
@@ -216,11 +193,7 @@ public class AccessTokenTest {
                         .grant(sg)
                         .build();
 
-        Claims claims =
-                Jwts.parser()
-                        .setSigningKey(SECRET.getBytes())
-                        .parseClaimsJws(token.toJwt())
-                        .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
 
@@ -244,11 +217,7 @@ public class AccessTokenTest {
                         .grant(trg)
                         .build();
 
-        Claims claims =
-                Jwts.parser()
-                        .setSigningKey(SECRET.getBytes())
-                        .parseClaimsJws(token.toJwt())
-                        .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
 
@@ -278,11 +247,7 @@ public class AccessTokenTest {
                 .nbf(new Date())
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
         Assert.assertTrue(claims.getNotBefore().getTime() <= new Date().getTime());
@@ -319,11 +284,7 @@ public class AccessTokenTest {
                 .grant(pvg)
                 .build();
 
-        Claims claims =
-            Jwts.parser()
-                .setSigningKey(SECRET.getBytes())
-                .parseClaimsJws(token.toJwt())
-                .getBody();
+        Claims claims = getClaimFromJwtToken(token);
 
         validateToken(claims);
         Map<String, Object> decodedGrants = (Map<String, Object>) claims.get("grants");
@@ -340,16 +301,21 @@ public class AccessTokenTest {
     }
 
     @Test()
-    public void testNullValues() throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
-        ChatGrant grant = new ChatGrant()
-            .setDeploymentRoleSid("RL123")
-            .setPushCredentialSid("CR123")
-            .setServiceSid("IS123");
-        String payload = mapper.writeValueAsString(grant);
-        Assert.assertFalse(payload.contains("endpoint_id"));
-        Assert.assertTrue(payload.contains("deployment_role_sid"));
-        Assert.assertTrue(payload.contains("push_credential_sid"));
-        Assert.assertTrue(payload.contains("service_sid"));
+    public void testNullValues() {
+        ChatGrant cg = new ChatGrant().setDeploymentRoleSid("RL123");
+        Jwt token =
+            new AccessToken.Builder(ACCOUNT_SID, SIGNING_KEY_SID, SECRET)
+                .grant(cg)
+                .build();
+
+        Claims claims = getClaimFromJwtToken(token);
+        
+        validateToken(claims);
+
+        Map<String, Object> decodedGrants = (Map<String, Object>) claims.get("grants");
+        Map<String, Object> grant = (Map<String, Object>) decodedGrants.get("chat");
+
+        Assert.assertEquals("RL123", grant.get("deployment_role_sid"));
+        Assert.assertFalse(grant.containsKey("endpoint_id"));
     }
 }


### PR DESCRIPTION
The JWT payloads should not contain null values. This fix ensures any null values do not get included when serializing the `Payload` class.

Reference: https://www.baeldung.com/jackson-ignore-null-fields

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the master branch
- [x] I have added tests that prove my fix is effective or that my feature works


