### PR TITLE
fix: adding new constructor

### DIFF
--- a/src/main/java/com/twilio/http/NetworkHttpClient.java
+++ b/src/main/java/com/twilio/http/NetworkHttpClient.java
@@ -34,11 +34,18 @@ public class NetworkHttpClient extends HttpClient {
      * Create a new HTTP Client.
      */
     public NetworkHttpClient() {
-        RequestConfig config = RequestConfig.custom()
+        this(RequestConfig.custom()
             .setConnectTimeout(CONNECTION_TIMEOUT)
             .setSocketTimeout(SOCKET_TIMEOUT)
-            .build();
+            .build()
+        );
+    }
 
+    /**
+     * Create a new HTTP Client with a custom request config.
+     * @param config a RequestConfig.
+     */
+    public NetworkHttpClient(RequestConfig config) {
         Collection<Header> headers = Lists.<Header>newArrayList(
             new BasicHeader("X-Twilio-Client", "java-" + Twilio.VERSION),
             new BasicHeader(HttpHeaders.USER_AGENT, "twilio-java/" + Twilio.VERSION + " (" + Twilio.JAVA_VERSION + ")"),


### PR DESCRIPTION
# Fixes #
Fixes #513 

This PR adds in a new constructor to the `NetworkHttpClient` class to take in a custom request config object.

### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the master branch
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation about the functionality in the appropriate .md file
- [X] I have added inline documentation to the code I modified
