### PR TITLE
fix: Fix datetime filter when the DateTime instances have timezone other than UTC

### DIFF
--- a/src/main/java/com/twilio/http/Request.java
+++ b/src/main/java/com/twilio/http/Request.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Range;
 import com.twilio.exception.ApiException;
 import com.twilio.exception.InvalidRequestException;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
 import javax.xml.bind.DatatypeConverter;
@@ -166,12 +167,12 @@ public class Request {
      */
     public void addQueryDateTimeRange(final String name, final Range<DateTime> range) {
         if (range.hasLowerBound()) {
-            String value = range.lowerEndpoint().toString(QUERY_STRING_DATE_TIME_FORMAT);
+            String value = range.lowerEndpoint().withZone(DateTimeZone.UTC).toString(QUERY_STRING_DATE_TIME_FORMAT);
             addQueryParam(name + ">", value);
         }
 
         if (range.hasUpperBound()) {
-            String value = range.upperEndpoint().toString(QUERY_STRING_DATE_TIME_FORMAT);
+            String value = range.upperEndpoint().withZone(DateTimeZone.UTC).toString(QUERY_STRING_DATE_TIME_FORMAT);
             addQueryParam(name + "<", value);
         }
     }

--- a/src/test/java/com/twilio/http/RequestTest.java
+++ b/src/test/java/com/twilio/http/RequestTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Range;
 import com.twilio.exception.ApiException;
 import com.twilio.rest.Domains;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 
@@ -111,7 +112,7 @@ public class RequestTest {
     @Test
     public void testAddQueryDateTimeRangeLowerBound() throws MalformedURLException {
         Request r = new Request(HttpMethod.GET, Domains.API.toString(), "/2010-04-01/foobar");
-        r.addQueryDateTimeRange("baz", Range.greaterThan(new DateTime(2014, 1, 1, 0, 0)));
+        r.addQueryDateTimeRange("baz", Range.greaterThan(new DateTime(2014, 1, 1, 0, 0, DateTimeZone.UTC)));
         URL url = r.constructURL();
         URL expected = new URL("https://api.twilio.com/2010-04-01/foobar?baz>=2014-01-01T00:00:00");
         assertUrlsEqual(expected, url);
@@ -120,7 +121,7 @@ public class RequestTest {
     @Test
     public void testAddQueryDateTimeRangeUpperBound() throws MalformedURLException {
         Request r = new Request(HttpMethod.GET, Domains.API.toString(), "/2010-04-01/foobar");
-        r.addQueryDateTimeRange("baz", Range.lessThan(new DateTime(2014, 1, 1, 22, 0)));
+        r.addQueryDateTimeRange("baz", Range.lessThan(new DateTime(2014, 1, 1, 22, 0, DateTimeZone.UTC)));
         URL url = r.constructURL();
         URL expected = new URL("https://api.twilio.com/2010-04-01/foobar?baz<=2014-01-01T22:00:00");
         assertUrlsEqual(expected, url);
@@ -129,9 +130,20 @@ public class RequestTest {
     @Test
     public void testAddQueryDateTimeRangeClosed() throws MalformedURLException {
         Request r = new Request(HttpMethod.GET, Domains.API.toString(), "/2010-04-01/foobar");
-        r.addQueryDateTimeRange("baz", Range.closed(new DateTime(2014, 1, 10, 14, 0), new DateTime(2014, 6, 1, 16, 0)));
+        r.addQueryDateTimeRange("baz", Range.closed(new DateTime(2014, 1, 10, 14, 0, DateTimeZone.UTC),
+                new DateTime(2014, 6, 1, 16, 0, DateTimeZone.UTC)));
         URL url = r.constructURL();
         URL expected = new URL("https://api.twilio.com/2010-04-01/foobar?baz>=2014-01-10T14:00:00&baz<=2014-06-01T16:00:00");
+        assertUrlsEqual(expected, url);
+    }
+
+    @Test
+    public void testAddQueryDateTimeRangeClosedNotUTC() throws MalformedURLException {
+        Request r = new Request(HttpMethod.GET, Domains.API.toString(), "/2010-04-01/foobar");
+        r.addQueryDateTimeRange("baz", Range.closed(new DateTime(2014, 1, 10, 14, 0, DateTimeZone.forID("America/Chicago")),
+                new DateTime(2014, 6, 1, 16, 0, DateTimeZone.forID("America/Chicago"))));
+        URL url = r.constructURL();
+        URL expected = new URL("https://api.twilio.com/2010-04-01/foobar?baz>=2014-01-10T20:00:00&baz<=2014-06-01T21:00:00");
         assertUrlsEqual(expected, url);
     }
 


### PR DESCRIPTION
# Fixes #

Fixes a bug in datetime filter when the DateTime instances are constructed with a timezone different than UTC. i.e.: `DateTime.now().minusMinutes(5)`. `QUERY_STRING_DATE_TIME_FORMAT` strips the timezone information from the query parameter.

### Checklist
- [x ] I acknowledge that all my contributions will be made under the project's license
- [ x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [ x] I have titled the PR appropriately
- [ x] I have updated my branch with the master branch
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified