### PR TITLE
feat: include API response headers in 'Last Response'

### DIFF
--- a/src/main/java/com/twilio/http/NetworkHttpClient.java
+++ b/src/main/java/com/twilio/http/NetworkHttpClient.java
@@ -129,7 +129,8 @@ public class NetworkHttpClient extends HttpClient {
             return new Response(
                 // Consume the entire HTTP response before returning the stream
                 entity == null ? null : new BufferedHttpEntity(entity).getContent(),
-                response.getStatusLine().getStatusCode()
+                response.getStatusLine().getStatusCode(),
+                response.getAllHeaders()
             );
         } catch (IOException e) {
             throw new ApiException(e.getMessage(), e);

--- a/src/main/java/com/twilio/http/Response.java
+++ b/src/main/java/com/twilio/http/Response.java
@@ -1,9 +1,9 @@
 package com.twilio.http;
 
 import com.twilio.exception.ApiException;
+import org.apache.http.Header;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Scanner;
@@ -13,37 +13,62 @@ public class Response {
     private final InputStream stream;
     private final String content;
     private final int statusCode;
+    private final Header[] headers;
 
     /**
      * Create a Response from content string and status code.
      *
-     * @param content content string
+     * @param content    content string
      * @param statusCode status code
      */
     public Response(final String content, final int statusCode) {
+        this(content, statusCode, null);
+    }
+
+    /**
+     * Create a Response from content string, status code, and headers.
+     *
+     * @param content    content string
+     * @param statusCode status code
+     * @param headers    headers
+     */
+    public Response(final String content, final int statusCode, final Header[] headers) {
         this.stream = null;
         this.content = content;
         this.statusCode = statusCode;
+        this.headers = headers;
     }
 
     /**
      * Create a Response from input stream and status code.
      *
-     * @param stream input stream
+     * @param stream     input stream
      * @param statusCode status code
      */
     public Response(final InputStream stream, final int statusCode) {
+        this(stream, statusCode, null);
+    }
+
+    /**
+     * Create a Response from input stream, status code, and headers.
+     *
+     * @param stream     input stream
+     * @param statusCode status code
+     * @param headers    headers
+     */
+    public Response(final InputStream stream, final int statusCode, final Header[] headers) {
         this.stream = stream;
         this.content = null;
         this.statusCode = statusCode;
+        this.headers = headers;
     }
 
     /**
      * Get the the content of the response.
      *
      * <p>
-     *     If there is a content string, that will be returned.
-     *     Otherwise, will get content from input stream
+     * If there is a content string, that will be returned.
+     * Otherwise, will get content from input stream
      * </p>
      *
      * @return the content string
@@ -87,5 +112,9 @@ public class Response {
 
     public int getStatusCode() {
         return statusCode;
+    }
+
+    public Header[] getHeaders() {
+        return headers;
     }
 }

--- a/src/main/java/com/twilio/http/ValidationClient.java
+++ b/src/main/java/com/twilio/http/ValidationClient.java
@@ -30,7 +30,7 @@ public class ValidationClient extends HttpClient {
 
     /**
      * Create a new ValidationClient.
-     * 
+     *
      * @param  accountSid Twilio Account SID
      * @param  credentialSid Twilio Credential SID
      * @param  signingKey Twilio Signing key
@@ -84,7 +84,8 @@ public class ValidationClient extends HttpClient {
             HttpResponse response = client.execute(builder.build());
             return new Response(
                 response.getEntity() == null ? null : response.getEntity().getContent(),
-                response.getStatusLine().getStatusCode()
+                response.getStatusLine().getStatusCode(),
+                response.getAllHeaders()
             );
         } catch (IOException e) {
             throw new ApiException(e.getMessage(), e);


### PR DESCRIPTION
The default HTTP client stores 'Last Request' and 'Last Response' information for access to more data about the raw API request/response. The response object did not contain the headers until now.