### PR TITLE
fix: allow API redirect responses

### DIFF
--- a/src/main/java/com/twilio/http/HttpClient.java
+++ b/src/main/java/com/twilio/http/HttpClient.java
@@ -1,5 +1,8 @@
 package com.twilio.http;
 
+import org.apache.http.client.RedirectStrategy;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+
 public abstract class HttpClient {
 
     public static final int ANY_500 = -500;
@@ -11,6 +14,9 @@ public abstract class HttpClient {
     public static final int[] RETRY_CODES = new int[]{ANY_500};
     public static final int RETRIES = 3;
     public static final long DELAY_MILLIS = 100L;
+
+    // Default redirect strategy to not auto-redirect for any methods (empty string array).
+    private RedirectStrategy redirectStrategy = new DefaultRedirectStrategy(new String[0]);
 
     private Response lastResponse;
     private Request lastRequest;
@@ -28,9 +34,9 @@ public abstract class HttpClient {
     /**
      * Make a request.
      *
-     * @param request request to make
-     * @param retryCodes codes used for retries
-     * @param retries max number of retries
+     * @param request     request to make
+     * @param retryCodes  codes used for retries
+     * @param retries     max number of retries
      * @param delayMillis delays between retries
      * @return Response of the HTTP request
      */
@@ -111,6 +117,14 @@ public abstract class HttpClient {
             }
         }
         return false;
+    }
+
+    public RedirectStrategy getRedirectStrategy() {
+        return redirectStrategy;
+    }
+
+    public void setRedirectStrategy(final RedirectStrategy redirectStrategy) {
+        this.redirectStrategy = redirectStrategy;
     }
 
     public abstract Response makeRequest(final Request request);

--- a/src/main/java/com/twilio/http/NetworkHttpClient.java
+++ b/src/main/java/com/twilio/http/NetworkHttpClient.java
@@ -64,12 +64,12 @@ public class NetworkHttpClient extends HttpClient {
 	      connectionManager.setDefaultMaxPerRoute(10);
 	      connectionManager.setMaxTotal(10*2);
 
-        clientBuilder
+        client = clientBuilder
             .setConnectionManager(connectionManager)
             .setDefaultRequestConfig(config)
-            .setDefaultHeaders(headers);
-
-        client = clientBuilder.build();
+            .setDefaultHeaders(headers)
+            .setRedirectStrategy(this.getRedirectStrategy())
+            .build();
     }
 
     /**
@@ -87,8 +87,9 @@ public class NetworkHttpClient extends HttpClient {
         );
 
         client = clientBuilder
-                .setDefaultHeaders(headers)
-                .build();
+            .setDefaultHeaders(headers)
+            .setRedirectStrategy(this.getRedirectStrategy())
+            .build();
     }
 
     /**

--- a/src/main/java/com/twilio/http/TwilioRestClient.java
+++ b/src/main/java/com/twilio/http/TwilioRestClient.java
@@ -11,7 +11,7 @@ public class TwilioRestClient {
     public static final Predicate<Integer> SUCCESS = new Predicate<Integer>() {
         @Override
         public boolean apply(Integer i) {
-            return i != null && i >= 200 && i < 300;
+            return i != null && i >= 200 && i < 400;
         }
     };
 

--- a/src/main/java/com/twilio/http/ValidationClient.java
+++ b/src/main/java/com/twilio/http/ValidationClient.java
@@ -7,6 +7,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeader;
@@ -53,6 +54,7 @@ public class ValidationClient extends HttpClient {
             .setDefaultHeaders(headers)
             .setMaxConnPerRoute(10)
             .addInterceptorLast(new ValidationInterceptor(accountSid, credentialSid, signingKey, privateKey))
+            .setRedirectStrategy(this.getRedirectStrategy())
             .build();
     }
 

--- a/src/test/java/com/twilio/http/TwilioRestClientTest.java
+++ b/src/test/java/com/twilio/http/TwilioRestClientTest.java
@@ -1,0 +1,36 @@
+package com.twilio.http;
+
+import com.twilio.Twilio;
+import com.twilio.rest.Domains;
+import com.twilio.rest.api.v2010.account.Message;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TwilioRestClientTest {
+    @Mocked
+    private TwilioRestClient twilioRestClient;
+
+    @Before
+    public void setUp() throws Exception {
+        Twilio.init("AC123", "AUTH TOKEN");
+    }
+
+    @Test
+    public void testFetchRedirect() {
+        new Expectations() {{
+            final Request request = new Request(HttpMethod.GET, Domains.API.toString(),
+                "/2010-04-01/Accounts/AC123/Messages/MM123.json");
+
+            twilioRestClient.request(request);
+            times = 1;
+            result = new Response("{\"redirect_to\": \"somewhere\"}", 307);
+        }};
+
+        final Message response = Message.fetcher("AC123", "MM123").fetch();
+        assertNotNull(response);
+    }
+}


### PR DESCRIPTION
Fetching a BulkExport for a single day returns a `307` with the AWS URL for the file. With this change, the URL will now be included in the response.