### PR TITLE
fix!: replace ICE Server URL properties with String types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -204,6 +204,35 @@ vg.setRoom("sid");
 String sid = vg.getRoom();
 ```
 
+### CHANGED - Updated `com.twilio.type.IceServer` URL types
+`IceServer` properties `url` and `urls` types have been changed from `java.net.URI` to `String`:
+```java
+// 7.x.x
+import com.twilio.rest.api.v2010.account.Token;
+import com.twilio.type.IceServer;
+import java.net.URI;
+
+Token token = Token.creator().create()
+
+for (IceServer iceServer : token.getIceServers()) {
+    URI url = iceServer.getUrl();
+    URI urls = iceServer.getUrls();
+}
+```
+
+```java
+// 8.x.x
+import com.twilio.rest.api.v2010.account.Token;
+import com.twilio.type.IceServer;
+
+Token token = Token.creator().create()
+
+for (IceServer iceServer : token.getIceServers()) {
+    String url = iceServer.getUrl();
+    String urls = iceServer.getUrls();
+}
+```
+
 [2017-12-15] 7.16.x to 7.17.x
 -----------------------------
 

--- a/src/main/java/com/twilio/type/IceServer.java
+++ b/src/main/java/com/twilio/type/IceServer.java
@@ -3,21 +3,18 @@ package com.twilio.type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.ToString;
-
-import java.net.URI;
-import java.util.Objects;
+import lombok.Data;
 
 /**
  * POJO representation of a Twilio ICE server.
  */
+@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ToString
 public class IceServer {
     private final String credential;
     private final String username;
-    private final URI url;
-    private final URI urls;
+    private final String url;
+    private final String urls;
 
 
     /**
@@ -31,50 +28,11 @@ public class IceServer {
     @JsonCreator
     public IceServer(@JsonProperty("credential") final String credential,
                      @JsonProperty("username") final String username,
-                     @JsonProperty("url") final URI url,
-                     @JsonProperty("urls") final URI urls) {
+                     @JsonProperty("url") final String url,
+                     @JsonProperty("urls") final String urls) {
         this.credential = credential;
         this.username = username;
         this.url = url;
         this.urls = urls;
-    }
-
-    public URI getUrl() {
-        return url;
-    }
-
-    public URI getUrls() {
-        return urls;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public String getCredential() {
-        return credential;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        IceServer other = (IceServer) o;
-
-        return (Objects.equals(credential, other.credential) &&
-            Objects.equals(username, other.username) &&
-            Objects.equals(url, other.url) &&
-            Objects.equals(urls, other.urls));
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(credential, username, url, urls);
     }
 }

--- a/src/test/java/com/twilio/type/IceServerTest.java
+++ b/src/test/java/com/twilio/type/IceServerTest.java
@@ -13,16 +13,16 @@ public class IceServerTest extends TypeTest {
     @Test
     public void testFromJson() throws IOException {
         String json = "{\n" +
-                "    \"credential\": \"apn\",\n" +
-                "    \"username\": \"twilio\",\n" +
-                "    \"url\": \"https://www.twilio.ca\",\n" +
-                "    \"urls\": \"https://www.twilio.ca\"\n" +
-                "}";
+            "    \"credential\": \"apn\",\n" +
+            "    \"username\": \"twilio\",\n" +
+            "    \"url\": \"https://www.twilio.ca\",\n" +
+            "    \"urls\": \"https://www.twilio.ca\"\n" +
+            "}";
 
         IceServer is = fromJson(json, IceServer.class);
-        Assert.assertEquals("https://www.twilio.ca", is.getUrl().toString());
-        Assert.assertEquals("https://www.twilio.ca", is.getUrls().toString());
-        Assert.assertEquals(is.getUrls().toString(), is.getUrl().toString());
+        Assert.assertEquals("https://www.twilio.ca", is.getUrl());
+        Assert.assertEquals("https://www.twilio.ca", is.getUrls());
+        Assert.assertEquals(is.getUrls(), is.getUrl());
         Assert.assertEquals("apn", is.getCredential());
         Assert.assertEquals("twilio", is.getUsername());
     }


### PR DESCRIPTION
> Developers MUST NOT use a generic hierarchical URI parser to parse a "stun" or "stuns" URI.

> Developers MUST NOT use a generic hierarchical URI parser to parse a "turn" or "turns" URI.

Fixes #400