### PR TITLE
test: change RequestTest to use flexapi instead of ip-messaging

### DIFF
--- a/src/test/java/com/twilio/http/RequestTest.java
+++ b/src/test/java/com/twilio/http/RequestTest.java
@@ -25,10 +25,10 @@ public class RequestTest {
 
     @Test
     public void testConstructorWithDomain() {
-        Request request = new Request(HttpMethod.GET, Domains.IPMESSAGING.toString(), "/v1/uri");
+        Request request = new Request(HttpMethod.GET, Domains.FLEXAPI.toString(), "/v1/uri");
         assertNotNull(request);
         assertEquals(HttpMethod.GET, request.getMethod());
-        assertEquals("https://chat.twilio.com/v1/uri", request.getUrl());
+        assertEquals("https://flex-api.twilio.com/v1/uri", request.getUrl());
     }
 
     @Test


### PR DESCRIPTION
# Fixes #

Change RequestTest to use flexapi instead of ip-messaging

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
