### PR TITLE
fix: serialize ZonedDateTime parameters to ISO-8601

### DIFF
--- a/src/main/java/com/twilio/rest/chat/v2/service/ChannelCreator.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/ChannelCreator.java
@@ -211,11 +211,11 @@ public class ChannelCreator extends Creator<Channel> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (createdBy != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/ChannelUpdater.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/ChannelUpdater.java
@@ -194,11 +194,11 @@ public class ChannelUpdater extends Updater<Channel> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (createdBy != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/channel/MemberCreator.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/channel/MemberCreator.java
@@ -210,15 +210,15 @@ public class MemberCreator extends Creator<Member> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/channel/MemberUpdater.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/channel/MemberUpdater.java
@@ -202,15 +202,15 @@ public class MemberUpdater extends Updater<Member> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/channel/MessageCreator.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/channel/MessageCreator.java
@@ -203,11 +203,11 @@ public class MessageCreator extends Creator<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (lastUpdatedBy != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/channel/MessageUpdater.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/channel/MessageUpdater.java
@@ -194,11 +194,11 @@ public class MessageUpdater extends Updater<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (lastUpdatedBy != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/user/UserChannelUpdater.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/user/UserChannelUpdater.java
@@ -136,7 +136,7 @@ public class UserChannelUpdater extends Updater<UserChannel> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
         }
     }
 }

--- a/src/main/java/com/twilio/rest/conversations/v1/ConversationCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/ConversationCreator.java
@@ -214,11 +214,11 @@ public class ConversationCreator extends Creator<Conversation> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (messagingServiceSid != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/ConversationUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/ConversationUpdater.java
@@ -206,11 +206,11 @@ public class ConversationUpdater extends Updater<Conversation> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/conversation/MessageCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/conversation/MessageCreator.java
@@ -180,11 +180,11 @@ public class MessageCreator extends Creator<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/conversation/MessageUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/conversation/MessageUpdater.java
@@ -172,11 +172,11 @@ public class MessageUpdater extends Updater<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/conversation/ParticipantCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/conversation/ParticipantCreator.java
@@ -222,11 +222,11 @@ public class ParticipantCreator extends Creator<Participant> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/conversation/ParticipantUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/conversation/ParticipantUpdater.java
@@ -197,11 +197,11 @@ public class ParticipantUpdater extends Updater<Participant> {
      */
     private void addPostParams(final Request request) {
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/ConversationCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/ConversationCreator.java
@@ -232,11 +232,11 @@ public class ConversationCreator extends Creator<Conversation> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (state != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/ConversationUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/ConversationUpdater.java
@@ -210,11 +210,11 @@ public class ConversationUpdater extends Updater<Conversation> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/conversation/MessageCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/conversation/MessageCreator.java
@@ -185,11 +185,11 @@ public class MessageCreator extends Creator<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/conversation/MessageUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/conversation/MessageUpdater.java
@@ -177,11 +177,11 @@ public class MessageUpdater extends Updater<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/conversation/ParticipantCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/conversation/ParticipantCreator.java
@@ -227,11 +227,11 @@ public class ParticipantCreator extends Creator<Participant> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/conversation/ParticipantUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/conversation/ParticipantUpdater.java
@@ -202,11 +202,11 @@ public class ParticipantUpdater extends Updater<Participant> {
      */
     private void addPostParams(final Request request) {
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (identity != null) {

--- a/src/main/java/com/twilio/rest/fax/v1/FaxReader.java
+++ b/src/main/java/com/twilio/rest/fax/v1/FaxReader.java
@@ -208,11 +208,11 @@ public class FaxReader extends Reader<Fax> {
         }
 
         if (dateCreatedOnOrBefore != null) {
-            request.addQueryParam("DateCreatedOnOrBefore", dateCreatedOnOrBefore.toString());
+            request.addQueryParam("DateCreatedOnOrBefore", dateCreatedOnOrBefore.toOffsetDateTime().toString());
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/ChannelCreator.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/ChannelCreator.java
@@ -211,11 +211,11 @@ public class ChannelCreator extends Creator<Channel> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (createdBy != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/ChannelUpdater.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/ChannelUpdater.java
@@ -194,11 +194,11 @@ public class ChannelUpdater extends Updater<Channel> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (createdBy != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MemberCreator.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MemberCreator.java
@@ -210,15 +210,15 @@ public class MemberCreator extends Creator<Member> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MemberUpdater.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MemberUpdater.java
@@ -202,15 +202,15 @@ public class MemberUpdater extends Updater<Member> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MessageCreator.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MessageCreator.java
@@ -203,11 +203,11 @@ public class MessageCreator extends Creator<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (lastUpdatedBy != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MessageUpdater.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MessageUpdater.java
@@ -194,11 +194,11 @@ public class MessageUpdater extends Updater<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toString());
+            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toString());
+            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
         }
 
         if (lastUpdatedBy != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/user/UserChannelUpdater.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/user/UserChannelUpdater.java
@@ -136,7 +136,7 @@ public class UserChannelUpdater extends Updater<UserChannel> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
         }
     }
 }

--- a/src/main/java/com/twilio/rest/monitor/v1/AlertReader.java
+++ b/src/main/java/com/twilio/rest/monitor/v1/AlertReader.java
@@ -189,11 +189,11 @@ public class AlertReader extends Reader<Alert> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/monitor/v1/EventReader.java
+++ b/src/main/java/com/twilio/rest/monitor/v1/EventReader.java
@@ -239,11 +239,11 @@ public class EventReader extends Reader<Event> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/preview/trustedComms/business/insights/ImpressionsRateFetcher.java
+++ b/src/main/java/com/twilio/rest/preview/trustedComms/business/insights/ImpressionsRateFetcher.java
@@ -178,11 +178,11 @@ public class ImpressionsRateFetcher extends Fetcher<ImpressionsRate> {
         }
 
         if (start != null) {
-            request.addQueryParam("Start", start.toString());
+            request.addQueryParam("Start", start.toOffsetDateTime().toString());
         }
 
         if (end != null) {
-            request.addQueryParam("End", end.toString());
+            request.addQueryParam("End", end.toOffsetDateTime().toString());
         }
 
         if (interval != null) {

--- a/src/main/java/com/twilio/rest/proxy/v1/service/SessionCreator.java
+++ b/src/main/java/com/twilio/rest/proxy/v1/service/SessionCreator.java
@@ -197,7 +197,7 @@ public class SessionCreator extends Creator<Session> {
         }
 
         if (dateExpiry != null) {
-            request.addPostParam("DateExpiry", dateExpiry.toString());
+            request.addPostParam("DateExpiry", dateExpiry.toOffsetDateTime().toString());
         }
 
         if (ttl != null) {

--- a/src/main/java/com/twilio/rest/proxy/v1/service/SessionUpdater.java
+++ b/src/main/java/com/twilio/rest/proxy/v1/service/SessionUpdater.java
@@ -142,7 +142,7 @@ public class SessionUpdater extends Updater<Session> {
      */
     private void addPostParams(final Request request) {
         if (dateExpiry != null) {
-            request.addPostParam("DateExpiry", dateExpiry.toString());
+            request.addPostParam("DateExpiry", dateExpiry.toOffsetDateTime().toString());
         }
 
         if (ttl != null) {

--- a/src/main/java/com/twilio/rest/serverless/v1/service/environment/LogReader.java
+++ b/src/main/java/com/twilio/rest/serverless/v1/service/environment/LogReader.java
@@ -206,11 +206,11 @@ public class LogReader extends Reader<Log> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/studio/v1/flow/ExecutionReader.java
+++ b/src/main/java/com/twilio/rest/studio/v1/flow/ExecutionReader.java
@@ -181,11 +181,11 @@ public class ExecutionReader extends Reader<Execution> {
      */
     private void addQueryParams(final Request request) {
         if (dateCreatedFrom != null) {
-            request.addQueryParam("DateCreatedFrom", dateCreatedFrom.toString());
+            request.addQueryParam("DateCreatedFrom", dateCreatedFrom.toOffsetDateTime().toString());
         }
 
         if (dateCreatedTo != null) {
-            request.addQueryParam("DateCreatedTo", dateCreatedTo.toString());
+            request.addQueryParam("DateCreatedTo", dateCreatedTo.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/studio/v2/flow/ExecutionReader.java
+++ b/src/main/java/com/twilio/rest/studio/v2/flow/ExecutionReader.java
@@ -185,11 +185,11 @@ public class ExecutionReader extends Reader<Execution> {
      */
     private void addQueryParams(final Request request) {
         if (dateCreatedFrom != null) {
-            request.addQueryParam("DateCreatedFrom", dateCreatedFrom.toString());
+            request.addQueryParam("DateCreatedFrom", dateCreatedFrom.toOffsetDateTime().toString());
         }
 
         if (dateCreatedTo != null) {
-            request.addQueryParam("DateCreatedTo", dateCreatedTo.toString());
+            request.addQueryParam("DateCreatedTo", dateCreatedTo.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/supersim/v1/UsageRecordReader.java
+++ b/src/main/java/com/twilio/rest/supersim/v1/UsageRecordReader.java
@@ -287,11 +287,11 @@ public class UsageRecordReader extends Reader<UsageRecord> {
         }
 
         if (startTime != null) {
-            request.addQueryParam("StartTime", startTime.toString());
+            request.addQueryParam("StartTime", startTime.toOffsetDateTime().toString());
         }
 
         if (endTime != null) {
-            request.addQueryParam("EndTime", endTime.toString());
+            request.addQueryParam("EndTime", endTime.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/EventReader.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/EventReader.java
@@ -294,7 +294,7 @@ public class EventReader extends Reader<Event> {
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (eventType != null) {
@@ -310,7 +310,7 @@ public class EventReader extends Reader<Event> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (taskQueueSid != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/WorkspaceCumulativeStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/WorkspaceCumulativeStatisticsFetcher.java
@@ -143,7 +143,7 @@ public class WorkspaceCumulativeStatisticsFetcher extends Fetcher<WorkspaceCumul
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (minutes != null) {
@@ -151,7 +151,7 @@ public class WorkspaceCumulativeStatisticsFetcher extends Fetcher<WorkspaceCumul
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/WorkspaceStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/WorkspaceStatisticsFetcher.java
@@ -147,11 +147,11 @@ public class WorkspaceStatisticsFetcher extends Fetcher<WorkspaceStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueueCumulativeStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueueCumulativeStatisticsFetcher.java
@@ -145,7 +145,7 @@ public class TaskQueueCumulativeStatisticsFetcher extends Fetcher<TaskQueueCumul
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (minutes != null) {
@@ -153,7 +153,7 @@ public class TaskQueueCumulativeStatisticsFetcher extends Fetcher<TaskQueueCumul
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueueStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueueStatisticsFetcher.java
@@ -146,7 +146,7 @@ public class TaskQueueStatisticsFetcher extends Fetcher<TaskQueueStatistics> {
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (minutes != null) {
@@ -154,7 +154,7 @@ public class TaskQueueStatisticsFetcher extends Fetcher<TaskQueueStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueuesStatisticsReader.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueuesStatisticsReader.java
@@ -232,7 +232,7 @@ public class TaskQueuesStatisticsReader extends Reader<TaskQueuesStatistics> {
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (friendlyName != null) {
@@ -244,7 +244,7 @@ public class TaskQueuesStatisticsReader extends Reader<TaskQueuesStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkerStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkerStatisticsFetcher.java
@@ -132,11 +132,11 @@ public class WorkerStatisticsFetcher extends Fetcher<WorkerStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkersCumulativeStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkersCumulativeStatisticsFetcher.java
@@ -124,7 +124,7 @@ public class WorkersCumulativeStatisticsFetcher extends Fetcher<WorkersCumulativ
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (minutes != null) {
@@ -132,7 +132,7 @@ public class WorkersCumulativeStatisticsFetcher extends Fetcher<WorkersCumulativ
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkersStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkersStatisticsFetcher.java
@@ -167,11 +167,11 @@ public class WorkersStatisticsFetcher extends Fetcher<WorkersStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (taskQueueSid != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/workflow/WorkflowCumulativeStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/workflow/WorkflowCumulativeStatisticsFetcher.java
@@ -148,7 +148,7 @@ public class WorkflowCumulativeStatisticsFetcher extends Fetcher<WorkflowCumulat
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (minutes != null) {
@@ -156,7 +156,7 @@ public class WorkflowCumulativeStatisticsFetcher extends Fetcher<WorkflowCumulat
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/workflow/WorkflowStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/workflow/WorkflowStatisticsFetcher.java
@@ -153,11 +153,11 @@ public class WorkflowStatisticsFetcher extends Fetcher<WorkflowStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toString());
+            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toString());
+            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/verify/v2/service/entity/ChallengeCreator.java
+++ b/src/main/java/com/twilio/rest/verify/v2/service/entity/ChallengeCreator.java
@@ -157,7 +157,7 @@ public class ChallengeCreator extends Creator<Challenge> {
         }
 
         if (expirationDate != null) {
-            request.addPostParam("ExpirationDate", expirationDate.toString());
+            request.addPostParam("ExpirationDate", expirationDate.toOffsetDateTime().toString());
         }
 
         if (details != null) {

--- a/src/main/java/com/twilio/rest/video/v1/CompositionHookReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/CompositionHookReader.java
@@ -209,11 +209,11 @@ public class CompositionHookReader extends Reader<CompositionHook> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
         }
 
         if (friendlyName != null) {

--- a/src/main/java/com/twilio/rest/video/v1/CompositionReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/CompositionReader.java
@@ -206,11 +206,11 @@ public class CompositionReader extends Reader<Composition> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
         }
 
         if (roomSid != null) {

--- a/src/main/java/com/twilio/rest/video/v1/RecordingReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/RecordingReader.java
@@ -251,11 +251,11 @@ public class RecordingReader extends Reader<Recording> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
         }
 
         if (mediaType != null) {

--- a/src/main/java/com/twilio/rest/video/v1/RoomReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/RoomReader.java
@@ -200,11 +200,11 @@ public class RoomReader extends Reader<Room> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/video/v1/room/ParticipantReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/room/ParticipantReader.java
@@ -215,11 +215,11 @@ public class ParticipantReader extends Reader<Participant> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/video/v1/room/RoomRecordingReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/room/RoomRecordingReader.java
@@ -215,11 +215,11 @@ public class RoomRecordingReader extends Reader<RoomRecording> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/wireless/v1/UsageRecordReader.java
+++ b/src/main/java/com/twilio/rest/wireless/v1/UsageRecordReader.java
@@ -181,11 +181,11 @@ public class UsageRecordReader extends Reader<UsageRecord> {
      */
     private void addQueryParams(final Request request) {
         if (end != null) {
-            request.addQueryParam("End", end.toString());
+            request.addQueryParam("End", end.toOffsetDateTime().toString());
         }
 
         if (start != null) {
-            request.addQueryParam("Start", start.toString());
+            request.addQueryParam("Start", start.toOffsetDateTime().toString());
         }
 
         if (granularity != null) {

--- a/src/main/java/com/twilio/rest/wireless/v1/sim/UsageRecordReader.java
+++ b/src/main/java/com/twilio/rest/wireless/v1/sim/UsageRecordReader.java
@@ -193,11 +193,11 @@ public class UsageRecordReader extends Reader<UsageRecord> {
      */
     private void addQueryParams(final Request request) {
         if (end != null) {
-            request.addQueryParam("End", end.toString());
+            request.addQueryParam("End", end.toOffsetDateTime().toString());
         }
 
         if (start != null) {
-            request.addQueryParam("Start", start.toString());
+            request.addQueryParam("Start", start.toOffsetDateTime().toString());
         }
 
         if (granularity != null) {


### PR DESCRIPTION
Fixes #592, Fixes #593 

Just using `toString()` is not sufficient to ensure ISO-8601 compatibility, which is required by Twilio APIs.

https://stackoverflow.com/a/43635374/1660457