### PR TITLE
chore: Enable maven depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 sudo: false
+cache:
+  directories:
+  - $HOME/.m2
 before_install:
   - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import --batch || true
   - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust --batch || true


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.