### PR TITLE
fix: date time conversion to String

### DIFF
--- a/src/main/java/com/twilio/rest/chat/v2/service/ChannelCreator.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/ChannelCreator.java
@@ -211,11 +211,11 @@ public class ChannelCreator extends Creator<Channel> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (createdBy != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/ChannelUpdater.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/ChannelUpdater.java
@@ -194,11 +194,11 @@ public class ChannelUpdater extends Updater<Channel> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (createdBy != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/channel/MemberCreator.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/channel/MemberCreator.java
@@ -210,15 +210,15 @@ public class MemberCreator extends Creator<Member> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toInstant().toString());
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/channel/MemberUpdater.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/channel/MemberUpdater.java
@@ -202,15 +202,15 @@ public class MemberUpdater extends Updater<Member> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toInstant().toString());
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/channel/MessageCreator.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/channel/MessageCreator.java
@@ -203,11 +203,11 @@ public class MessageCreator extends Creator<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (lastUpdatedBy != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/channel/MessageUpdater.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/channel/MessageUpdater.java
@@ -194,11 +194,11 @@ public class MessageUpdater extends Updater<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (lastUpdatedBy != null) {

--- a/src/main/java/com/twilio/rest/chat/v2/service/user/UserChannelUpdater.java
+++ b/src/main/java/com/twilio/rest/chat/v2/service/user/UserChannelUpdater.java
@@ -136,7 +136,7 @@ public class UserChannelUpdater extends Updater<UserChannel> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toInstant().toString());
         }
     }
 }

--- a/src/main/java/com/twilio/rest/conversations/v1/ConversationCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/ConversationCreator.java
@@ -214,11 +214,11 @@ public class ConversationCreator extends Creator<Conversation> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (messagingServiceSid != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/ConversationUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/ConversationUpdater.java
@@ -220,11 +220,11 @@ public class ConversationUpdater extends Updater<Conversation> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/conversation/MessageCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/conversation/MessageCreator.java
@@ -180,11 +180,11 @@ public class MessageCreator extends Creator<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/conversation/MessageUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/conversation/MessageUpdater.java
@@ -172,11 +172,11 @@ public class MessageUpdater extends Updater<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/conversation/ParticipantCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/conversation/ParticipantCreator.java
@@ -222,11 +222,11 @@ public class ParticipantCreator extends Creator<Participant> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/conversation/ParticipantUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/conversation/ParticipantUpdater.java
@@ -227,11 +227,11 @@ public class ParticipantUpdater extends Updater<Participant> {
      */
     private void addPostParams(final Request request) {
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/ConversationCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/ConversationCreator.java
@@ -233,11 +233,11 @@ public class ConversationCreator extends Creator<Conversation> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (state != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/ConversationUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/ConversationUpdater.java
@@ -225,11 +225,11 @@ public class ConversationUpdater extends Updater<Conversation> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/conversation/MessageCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/conversation/MessageCreator.java
@@ -185,11 +185,11 @@ public class MessageCreator extends Creator<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/conversation/MessageUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/conversation/MessageUpdater.java
@@ -177,11 +177,11 @@ public class MessageUpdater extends Updater<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/conversation/ParticipantCreator.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/conversation/ParticipantCreator.java
@@ -227,11 +227,11 @@ public class ParticipantCreator extends Creator<Participant> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/conversations/v1/service/conversation/ParticipantUpdater.java
+++ b/src/main/java/com/twilio/rest/conversations/v1/service/conversation/ParticipantUpdater.java
@@ -232,11 +232,11 @@ public class ParticipantUpdater extends Updater<Participant> {
      */
     private void addPostParams(final Request request) {
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (identity != null) {

--- a/src/main/java/com/twilio/rest/fax/v1/FaxReader.java
+++ b/src/main/java/com/twilio/rest/fax/v1/FaxReader.java
@@ -208,11 +208,11 @@ public class FaxReader extends Reader<Fax> {
         }
 
         if (dateCreatedOnOrBefore != null) {
-            request.addQueryParam("DateCreatedOnOrBefore", dateCreatedOnOrBefore.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedOnOrBefore", dateCreatedOnOrBefore.toInstant().toString());
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/insights/v1/RoomReader.java
+++ b/src/main/java/com/twilio/rest/insights/v1/RoomReader.java
@@ -243,11 +243,11 @@ public class RoomReader extends Reader<Room> {
         }
 
         if (createdAfter != null) {
-            request.addQueryParam("CreatedAfter", createdAfter.toOffsetDateTime().toString());
+            request.addQueryParam("CreatedAfter", createdAfter.toInstant().toString());
         }
 
         if (createdBefore != null) {
-            request.addQueryParam("CreatedBefore", createdBefore.toOffsetDateTime().toString());
+            request.addQueryParam("CreatedBefore", createdBefore.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/ChannelCreator.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/ChannelCreator.java
@@ -194,11 +194,11 @@ public class ChannelCreator extends Creator<Channel> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (createdBy != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/ChannelUpdater.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/ChannelUpdater.java
@@ -182,11 +182,11 @@ public class ChannelUpdater extends Updater<Channel> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (createdBy != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MemberCreator.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MemberCreator.java
@@ -186,15 +186,15 @@ public class MemberCreator extends Creator<Member> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toInstant().toString());
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MemberUpdater.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MemberUpdater.java
@@ -182,15 +182,15 @@ public class MemberUpdater extends Updater<Member> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toInstant().toString());
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (attributes != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MessageCreator.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MessageCreator.java
@@ -190,11 +190,11 @@ public class MessageCreator extends Creator<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (lastUpdatedBy != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MessageUpdater.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/channel/MessageUpdater.java
@@ -182,11 +182,11 @@ public class MessageUpdater extends Updater<Message> {
         }
 
         if (dateCreated != null) {
-            request.addPostParam("DateCreated", dateCreated.toOffsetDateTime().toString());
+            request.addPostParam("DateCreated", dateCreated.toInstant().toString());
         }
 
         if (dateUpdated != null) {
-            request.addPostParam("DateUpdated", dateUpdated.toOffsetDateTime().toString());
+            request.addPostParam("DateUpdated", dateUpdated.toInstant().toString());
         }
 
         if (lastUpdatedBy != null) {

--- a/src/main/java/com/twilio/rest/ipmessaging/v2/service/user/UserChannelUpdater.java
+++ b/src/main/java/com/twilio/rest/ipmessaging/v2/service/user/UserChannelUpdater.java
@@ -122,7 +122,7 @@ public class UserChannelUpdater extends Updater<UserChannel> {
         }
 
         if (lastConsumptionTimestamp != null) {
-            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toOffsetDateTime().toString());
+            request.addPostParam("LastConsumptionTimestamp", lastConsumptionTimestamp.toInstant().toString());
         }
     }
 }

--- a/src/main/java/com/twilio/rest/monitor/v1/AlertReader.java
+++ b/src/main/java/com/twilio/rest/monitor/v1/AlertReader.java
@@ -189,11 +189,11 @@ public class AlertReader extends Reader<Alert> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/monitor/v1/EventReader.java
+++ b/src/main/java/com/twilio/rest/monitor/v1/EventReader.java
@@ -239,11 +239,11 @@ public class EventReader extends Reader<Event> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/proxy/v1/service/SessionCreator.java
+++ b/src/main/java/com/twilio/rest/proxy/v1/service/SessionCreator.java
@@ -197,7 +197,7 @@ public class SessionCreator extends Creator<Session> {
         }
 
         if (dateExpiry != null) {
-            request.addPostParam("DateExpiry", dateExpiry.toOffsetDateTime().toString());
+            request.addPostParam("DateExpiry", dateExpiry.toInstant().toString());
         }
 
         if (ttl != null) {

--- a/src/main/java/com/twilio/rest/proxy/v1/service/SessionUpdater.java
+++ b/src/main/java/com/twilio/rest/proxy/v1/service/SessionUpdater.java
@@ -142,7 +142,7 @@ public class SessionUpdater extends Updater<Session> {
      */
     private void addPostParams(final Request request) {
         if (dateExpiry != null) {
-            request.addPostParam("DateExpiry", dateExpiry.toOffsetDateTime().toString());
+            request.addPostParam("DateExpiry", dateExpiry.toInstant().toString());
         }
 
         if (ttl != null) {

--- a/src/main/java/com/twilio/rest/serverless/v1/service/environment/LogReader.java
+++ b/src/main/java/com/twilio/rest/serverless/v1/service/environment/LogReader.java
@@ -205,11 +205,11 @@ public class LogReader extends Reader<Log> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/studio/v1/flow/ExecutionReader.java
+++ b/src/main/java/com/twilio/rest/studio/v1/flow/ExecutionReader.java
@@ -181,11 +181,11 @@ public class ExecutionReader extends Reader<Execution> {
      */
     private void addQueryParams(final Request request) {
         if (dateCreatedFrom != null) {
-            request.addQueryParam("DateCreatedFrom", dateCreatedFrom.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedFrom", dateCreatedFrom.toInstant().toString());
         }
 
         if (dateCreatedTo != null) {
-            request.addQueryParam("DateCreatedTo", dateCreatedTo.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedTo", dateCreatedTo.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/studio/v2/flow/ExecutionReader.java
+++ b/src/main/java/com/twilio/rest/studio/v2/flow/ExecutionReader.java
@@ -181,11 +181,11 @@ public class ExecutionReader extends Reader<Execution> {
      */
     private void addQueryParams(final Request request) {
         if (dateCreatedFrom != null) {
-            request.addQueryParam("DateCreatedFrom", dateCreatedFrom.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedFrom", dateCreatedFrom.toInstant().toString());
         }
 
         if (dateCreatedTo != null) {
-            request.addQueryParam("DateCreatedTo", dateCreatedTo.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedTo", dateCreatedTo.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/supersim/v1/UsageRecordReader.java
+++ b/src/main/java/com/twilio/rest/supersim/v1/UsageRecordReader.java
@@ -286,11 +286,11 @@ public class UsageRecordReader extends Reader<UsageRecord> {
         }
 
         if (startTime != null) {
-            request.addQueryParam("StartTime", startTime.toOffsetDateTime().toString());
+            request.addQueryParam("StartTime", startTime.toInstant().toString());
         }
 
         if (endTime != null) {
-            request.addQueryParam("EndTime", endTime.toOffsetDateTime().toString());
+            request.addQueryParam("EndTime", endTime.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/EventReader.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/EventReader.java
@@ -294,7 +294,7 @@ public class EventReader extends Reader<Event> {
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (eventType != null) {
@@ -310,7 +310,7 @@ public class EventReader extends Reader<Event> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (taskQueueSid != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/WorkspaceCumulativeStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/WorkspaceCumulativeStatisticsFetcher.java
@@ -143,7 +143,7 @@ public class WorkspaceCumulativeStatisticsFetcher extends Fetcher<WorkspaceCumul
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (minutes != null) {
@@ -151,7 +151,7 @@ public class WorkspaceCumulativeStatisticsFetcher extends Fetcher<WorkspaceCumul
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/WorkspaceStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/WorkspaceStatisticsFetcher.java
@@ -147,11 +147,11 @@ public class WorkspaceStatisticsFetcher extends Fetcher<WorkspaceStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueueCumulativeStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueueCumulativeStatisticsFetcher.java
@@ -145,7 +145,7 @@ public class TaskQueueCumulativeStatisticsFetcher extends Fetcher<TaskQueueCumul
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (minutes != null) {
@@ -153,7 +153,7 @@ public class TaskQueueCumulativeStatisticsFetcher extends Fetcher<TaskQueueCumul
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueueStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueueStatisticsFetcher.java
@@ -146,7 +146,7 @@ public class TaskQueueStatisticsFetcher extends Fetcher<TaskQueueStatistics> {
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (minutes != null) {
@@ -154,7 +154,7 @@ public class TaskQueueStatisticsFetcher extends Fetcher<TaskQueueStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueuesStatisticsReader.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/taskqueue/TaskQueuesStatisticsReader.java
@@ -232,7 +232,7 @@ public class TaskQueuesStatisticsReader extends Reader<TaskQueuesStatistics> {
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (friendlyName != null) {
@@ -244,7 +244,7 @@ public class TaskQueuesStatisticsReader extends Reader<TaskQueuesStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkerStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkerStatisticsFetcher.java
@@ -132,11 +132,11 @@ public class WorkerStatisticsFetcher extends Fetcher<WorkerStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkersCumulativeStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkersCumulativeStatisticsFetcher.java
@@ -124,7 +124,7 @@ public class WorkersCumulativeStatisticsFetcher extends Fetcher<WorkersCumulativ
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (minutes != null) {
@@ -132,7 +132,7 @@ public class WorkersCumulativeStatisticsFetcher extends Fetcher<WorkersCumulativ
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkersStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/worker/WorkersStatisticsFetcher.java
@@ -167,11 +167,11 @@ public class WorkersStatisticsFetcher extends Fetcher<WorkersStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (taskQueueSid != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/workflow/WorkflowCumulativeStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/workflow/WorkflowCumulativeStatisticsFetcher.java
@@ -148,7 +148,7 @@ public class WorkflowCumulativeStatisticsFetcher extends Fetcher<WorkflowCumulat
      */
     private void addQueryParams(final Request request) {
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (minutes != null) {
@@ -156,7 +156,7 @@ public class WorkflowCumulativeStatisticsFetcher extends Fetcher<WorkflowCumulat
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/taskrouter/v1/workspace/workflow/WorkflowStatisticsFetcher.java
+++ b/src/main/java/com/twilio/rest/taskrouter/v1/workspace/workflow/WorkflowStatisticsFetcher.java
@@ -153,11 +153,11 @@ public class WorkflowStatisticsFetcher extends Fetcher<WorkflowStatistics> {
         }
 
         if (startDate != null) {
-            request.addQueryParam("StartDate", startDate.toOffsetDateTime().toString());
+            request.addQueryParam("StartDate", startDate.toInstant().toString());
         }
 
         if (endDate != null) {
-            request.addQueryParam("EndDate", endDate.toOffsetDateTime().toString());
+            request.addQueryParam("EndDate", endDate.toInstant().toString());
         }
 
         if (taskChannel != null) {

--- a/src/main/java/com/twilio/rest/verify/v2/VerificationAttemptReader.java
+++ b/src/main/java/com/twilio/rest/verify/v2/VerificationAttemptReader.java
@@ -180,11 +180,11 @@ public class VerificationAttemptReader extends Reader<VerificationAttempt> {
      */
     private void addQueryParams(final Request request) {
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toInstant().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toInstant().toString());
         }
 
         if (channelDataTo != null) {

--- a/src/main/java/com/twilio/rest/verify/v2/service/entity/ChallengeCreator.java
+++ b/src/main/java/com/twilio/rest/verify/v2/service/entity/ChallengeCreator.java
@@ -160,7 +160,7 @@ public class ChallengeCreator extends Creator<Challenge> {
         }
 
         if (expirationDate != null) {
-            request.addPostParam("ExpirationDate", expirationDate.toOffsetDateTime().toString());
+            request.addPostParam("ExpirationDate", expirationDate.toInstant().toString());
         }
 
         if (detailsMessage != null) {

--- a/src/main/java/com/twilio/rest/video/v1/CompositionHookReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/CompositionHookReader.java
@@ -209,11 +209,11 @@ public class CompositionHookReader extends Reader<CompositionHook> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toInstant().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toInstant().toString());
         }
 
         if (friendlyName != null) {

--- a/src/main/java/com/twilio/rest/video/v1/CompositionReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/CompositionReader.java
@@ -206,11 +206,11 @@ public class CompositionReader extends Reader<Composition> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toInstant().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toInstant().toString());
         }
 
         if (roomSid != null) {

--- a/src/main/java/com/twilio/rest/video/v1/RecordingReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/RecordingReader.java
@@ -251,11 +251,11 @@ public class RecordingReader extends Reader<Recording> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toInstant().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toInstant().toString());
         }
 
         if (mediaType != null) {

--- a/src/main/java/com/twilio/rest/video/v1/RoomReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/RoomReader.java
@@ -200,11 +200,11 @@ public class RoomReader extends Reader<Room> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toInstant().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/video/v1/room/ParticipantReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/room/ParticipantReader.java
@@ -215,11 +215,11 @@ public class ParticipantReader extends Reader<Participant> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toInstant().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/video/v1/room/RoomRecordingReader.java
+++ b/src/main/java/com/twilio/rest/video/v1/room/RoomRecordingReader.java
@@ -215,11 +215,11 @@ public class RoomRecordingReader extends Reader<RoomRecording> {
         }
 
         if (dateCreatedAfter != null) {
-            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedAfter", dateCreatedAfter.toInstant().toString());
         }
 
         if (dateCreatedBefore != null) {
-            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toOffsetDateTime().toString());
+            request.addQueryParam("DateCreatedBefore", dateCreatedBefore.toInstant().toString());
         }
 
         if (getPageSize() != null) {

--- a/src/main/java/com/twilio/rest/wireless/v1/UsageRecordReader.java
+++ b/src/main/java/com/twilio/rest/wireless/v1/UsageRecordReader.java
@@ -181,11 +181,11 @@ public class UsageRecordReader extends Reader<UsageRecord> {
      */
     private void addQueryParams(final Request request) {
         if (end != null) {
-            request.addQueryParam("End", end.toOffsetDateTime().toString());
+            request.addQueryParam("End", end.toInstant().toString());
         }
 
         if (start != null) {
-            request.addQueryParam("Start", start.toOffsetDateTime().toString());
+            request.addQueryParam("Start", start.toInstant().toString());
         }
 
         if (granularity != null) {

--- a/src/main/java/com/twilio/rest/wireless/v1/sim/UsageRecordReader.java
+++ b/src/main/java/com/twilio/rest/wireless/v1/sim/UsageRecordReader.java
@@ -193,11 +193,11 @@ public class UsageRecordReader extends Reader<UsageRecord> {
      */
     private void addQueryParams(final Request request) {
         if (end != null) {
-            request.addQueryParam("End", end.toOffsetDateTime().toString());
+            request.addQueryParam("End", end.toInstant().toString());
         }
 
         if (start != null) {
-            request.addQueryParam("Start", start.toOffsetDateTime().toString());
+            request.addQueryParam("Start", start.toInstant().toString());
         }
 
         if (granularity != null) {

--- a/src/test/java/com/twilio/converter/DateConverterTest.java
+++ b/src/test/java/com/twilio/converter/DateConverterTest.java
@@ -83,4 +83,12 @@ public class DateConverterTest {
         ZonedDateTime dateTime = DateConverter.iso8601DateTimeFromString("2016-01-15T21:49:24Z");
         Assert.assertNotNull(dateTime);
     }
+
+    @Test
+    public void testISO8601DateTimeConversion() {
+        String dateTimeString = "2016-01-15T21:49:00Z";
+        ZonedDateTime dateTime = DateConverter.iso8601DateTimeFromString(dateTimeString);
+        Assert.assertEquals(dateTimeString, dateTime.toInstant().toString());
+    }
+
 }


### PR DESCRIPTION
Java `OffsetDateTime` Objects truncate zero fields, whereas `Instant` Objects do not. `ZonedDateTime` Objects should be converted to the proper format via `ZonedDateTime.toInstant().toString()`. The added test failed using the previous conversion process, `ZonedDateTime.toOffsetDateTime().toString()`, due to the seconds being truncated. 