### PR TITLE
fix: deploy issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ cache:
   directories:
   - "$HOME/.m2"
 before_install:
+- curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+- sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+- sudo apt-get update
+- sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+- docker --version
 - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import --batch || true
 - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust --batch
   || true


### PR DESCRIPTION
Deploy fails with the docker-ce-18.x.x and needs to be upgraded to 20.x

[Failed job](https://app.travis-ci.com/github/twilio/twilio-java/jobs/536287600)
https://github.com/docker-library/openjdk/issues/465
https://github.com/carlossg/docker-maven/issues/221