### PR TITLE
chore: setup for XML deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,11 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>

--- a/src/main/java/com/twilio/twiml/TwiML.java
+++ b/src/main/java/com/twilio/twiml/TwiML.java
@@ -210,6 +210,7 @@ public abstract class TwiML {
             // Necessary to avoid conflict between <lang> tag and xml:lang attribute when deserializing XML.
             // See: https://github.com/FasterXML/jackson-dataformat-xml/issues/65
             xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
+            xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
         }
         protected static final ObjectMapper OBJECT_MAPPER = new XmlMapper(
             new XmlFactory(xmlInputFactory, new WstxOutputFactory()))

--- a/src/main/java/com/twilio/twiml/TwiML.java
+++ b/src/main/java/com/twilio/twiml/TwiML.java
@@ -205,16 +205,16 @@ public abstract class TwiML {
      * Create a new {@code TwiML} node
      */
     public static class Builder<T extends Builder<T>> {
-        private static final XMLInputFactory xmlInputFactory = new WstxInputFactory();
+        private static final XMLInputFactory XML_INPUT_FACTORY = new WstxInputFactory();
         static {
             // Necessary to avoid conflict between <lang> tag and xml:lang attribute when deserializing XML.
             // See: https://github.com/FasterXML/jackson-dataformat-xml/issues/65
-            xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
-            xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-            xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            XML_INPUT_FACTORY.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
+            XML_INPUT_FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            XML_INPUT_FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         }
         protected static final ObjectMapper OBJECT_MAPPER = new XmlMapper(
-            new XmlFactory(xmlInputFactory, new WstxOutputFactory()))
+            new XmlFactory(XML_INPUT_FACTORY, new WstxOutputFactory()))
                 .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true)
                 .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
 

--- a/src/main/java/com/twilio/twiml/TwiML.java
+++ b/src/main/java/com/twilio/twiml/TwiML.java
@@ -1,6 +1,12 @@
 package com.twilio.twiml;
 
-import com.twilio.http.TwilioRestClient;
+import com.ctc.wstx.stax.WstxInputFactory;
+import com.ctc.wstx.stax.WstxOutputFactory;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +16,7 @@ import org.w3c.dom.Node;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -198,6 +205,17 @@ public abstract class TwiML {
      * Create a new {@code TwiML} node
      */
     public static class Builder<T extends Builder<T>> {
+        private static final XMLInputFactory xmlInputFactory = new WstxInputFactory();
+        static {
+            // Necessary to avoid conflict between <lang> tag and xml:lang attribute when deserializing XML.
+            // See: https://github.com/FasterXML/jackson-dataformat-xml/issues/65
+            xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
+        }
+        protected static final ObjectMapper OBJECT_MAPPER = new XmlMapper(
+            new XmlFactory(xmlInputFactory, new WstxOutputFactory()))
+                .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true)
+                .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+
         protected Map<String, String> options = new HashMap<>();
         protected List<TwiML> children = new ArrayList<>();
 
@@ -213,6 +231,7 @@ public abstract class TwiML {
         /**
          * Add a text node as a child element
          */
+        @JacksonXmlText
         public T addText(String text) {
             this.children.add(new Text(text));
             return (T) this;

--- a/src/main/java/com/twilio/twiml/TwiML.java
+++ b/src/main/java/com/twilio/twiml/TwiML.java
@@ -211,6 +211,7 @@ public abstract class TwiML {
             // See: https://github.com/FasterXML/jackson-dataformat-xml/issues/65
             xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
             xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         }
         protected static final ObjectMapper OBJECT_MAPPER = new XmlMapper(
             new XmlFactory(xmlInputFactory, new WstxOutputFactory()))


### PR DESCRIPTION
This PR adds an ObjectMapper accessible to all TwiML Builder subclasses. It also annotates the builder's `addText` method. Both of these changes are necessary for the upcoming XML deserialization support for TwiML (see internal PR). 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-java/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
