### PR TITLE
[DI-1920] fix: set socket config with blocking operation timeout

### DIFF
--- a/src/main/java/com/twilio/http/HttpClient.java
+++ b/src/main/java/com/twilio/http/HttpClient.java
@@ -1,9 +1,25 @@
 package com.twilio.http;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.http.client.RedirectStrategy;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.SocketConfig;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 
 public abstract class HttpClient {
+
+    public static final int CONNECTION_TIMEOUT = 10000;
+    public static final int SOCKET_TIMEOUT = 30500;
+    public static final RequestConfig DEFAULT_REQUEST_CONFIG = RequestConfig
+        .custom()
+        .setConnectTimeout(CONNECTION_TIMEOUT)
+        .setSocketTimeout(SOCKET_TIMEOUT)
+        .build();
+    public static final SocketConfig DEFAULT_SOCKET_CONFIG = SocketConfig
+        .custom()
+        .setSoTimeout(SOCKET_TIMEOUT)
+        .build();
 
     public static final int ANY_500 = -500;
     public static final int ANY_400 = -400;
@@ -11,14 +27,18 @@ public abstract class HttpClient {
     public static final int ANY_200 = -200;
     public static final int ANY_100 = -100;
 
-    public static final int[] RETRY_CODES = new int[]{ANY_500};
+    public static final int[] RETRY_CODES = new int[] {ANY_500};
     public static final int RETRIES = 3;
     public static final long DELAY_MILLIS = 100L;
 
     // Default redirect strategy to not auto-redirect for any methods (empty string array).
+    @Getter
+    @Setter
     private RedirectStrategy redirectStrategy = new DefaultRedirectStrategy(new String[0]);
 
+    @Getter
     private Response lastResponse;
+    @Getter
     private Request lastRequest;
 
     /**
@@ -66,14 +86,6 @@ public abstract class HttpClient {
         return response;
     }
 
-    public Response getLastResponse() {
-        return lastResponse;
-    }
-
-    public Request getLastRequest() {
-        return lastRequest;
-    }
-
     protected boolean shouldRetry(final Response response, final int[] retryCodes) {
         if (response == null) {
             return true;
@@ -117,14 +129,6 @@ public abstract class HttpClient {
             }
         }
         return false;
-    }
-
-    public RedirectStrategy getRedirectStrategy() {
-        return redirectStrategy;
-    }
-
-    public void setRedirectStrategy(final RedirectStrategy redirectStrategy) {
-        this.redirectStrategy = redirectStrategy;
     }
 
     public abstract Response makeRequest(final Request request);


### PR DESCRIPTION
Sets a default socket config with timeout for all connections. Note that this must be applied to the connection manger and not the client builder. The client builder default socket config is only used when not given a connection manager.

Fixes #663 
