### PR TITLE
fix: support setting null account sid

### DIFF
--- a/src/main/java/com/twilio/Twilio.java
+++ b/src/main/java/com/twilio/Twilio.java
@@ -116,14 +116,9 @@ public class Twilio {
      * Set the account sid.
      *
      * @param accountSid account sid to use
-     * @throws AuthenticationException if account sid is null
      */
     public static synchronized void setAccountSid(final String accountSid) {
-        if (accountSid == null) {
-            throw new AuthenticationException("AccountSid can not be null");
-        }
-
-        if (!accountSid.equals(Twilio.accountSid)) {
+        if (!Objects.equals(accountSid, Twilio.accountSid)) {
             Twilio.invalidate();
         }
 


### PR DESCRIPTION
# Fixes #

Account SID is a nullable field, we should allow setting the accountSid to null for users managing multiple rest clients

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-java/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
