### PR TITLE
fix: reset account sid when using username and password only

### DIFF
--- a/src/main/java/com/twilio/Twilio.java
+++ b/src/main/java/com/twilio/Twilio.java
@@ -61,6 +61,7 @@ public class Twilio {
     public static synchronized void init(final String username, final String password) {
         Twilio.setUsername(username);
         Twilio.setPassword(password);
+        Twilio.setAccountSid(null);
     }
 
     /**


### PR DESCRIPTION
# Fixes #

Following https://github.com/twilio/twilio-java/pull/688, we should sets account sid to null if it's not used for current form of authentication

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-java/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
