### PR TITLE
chore: bump jackson to 2.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,8 +167,7 @@
     </profile>
   </profiles>
   <properties>
-    <jackson.version>2.13.4</jackson.version>
-    <jackson-databind.version>2.13.4.2</jackson-databind.version>
+    <jackson.version>2.14.0</jackson.version>
     <javadoc.plugin.version>3.3.1</javadoc.plugin.version>
     <jjwt.version>0.11.2</jjwt.version>
     <skip.tests>false</skip.tests>
@@ -179,15 +178,6 @@
     <sonar.coverage.exclusions>**/test/**/*.*,**/rest/**/*.*</sonar.coverage.exclusions>
     <sonar.cpd.exclusions>**/rest/**/*.*</sonar.cpd.exclusions>
   </properties>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson-databind.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -256,7 +246,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson-databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
Bump jackson version to 2.14.0 instead of only bumping the jackson-databind version from PR #720.
