### PR TITLE
feat: Support custom ObjectMappers, with singleton defaults

### DIFF
--- a/src/main/java/com/twilio/http/TwilioRestClient.java
+++ b/src/main/java/com/twilio/http/TwilioRestClient.java
@@ -51,14 +51,8 @@ public class TwilioRestClient {
         this.region = b.region;
         this.edge = b.edge;
         this.httpClient = b.httpClient;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = b.objectMapper;
         this.userAgentExtensions = b.userAgentExtensions;
-
-        // This module configures the ObjectMapper to use
-        // public API methods for manipulating java.time.*
-        // classes. The alternative is to use reflection which
-        // generates warnings from the module system on Java 9+
-        objectMapper.registerModule(new JavaTimeModule());
     }
 
     /**
@@ -71,7 +65,7 @@ public class TwilioRestClient {
         if (username != null && password != null) {
             request.setAuth(username, password);
         } else if (authStrategy != null) {
-           request.setAuth(authStrategy);
+            request.setAuth(authStrategy);
         }
 
         if (region != null)
@@ -106,6 +100,13 @@ public class TwilioRestClient {
     }
 
     public static class Builder {
+        // This module configures the ObjectMapper to use
+        // public API methods for manipulating java.time.*
+        // classes. The alternative is to use reflection which
+        // generates warnings from the module system on Java 9+
+        private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
         private String username;
         private String password;
         private AuthStrategy authStrategy;
@@ -114,6 +115,7 @@ public class TwilioRestClient {
         private String edge;
         private HttpClient httpClient;
         private List<String> userAgentExtensions;
+        private ObjectMapper objectMapper = DEFAULT_OBJECT_MAPPER;
 
         /**
          * Create a new Twilio Rest Client.
@@ -160,6 +162,11 @@ public class TwilioRestClient {
             if (userAgentExtensions != null && !userAgentExtensions.isEmpty()) {
                 this.userAgentExtensions = new ArrayList<>(userAgentExtensions);
             }
+            return this;
+        }
+
+        public Builder objectMapper(final ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
             return this;
         }
 

--- a/src/main/java/com/twilio/http/TwilioRestClient.java
+++ b/src/main/java/com/twilio/http/TwilioRestClient.java
@@ -3,18 +3,14 @@ package com.twilio.http;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.twilio.auth_strategy.AuthStrategy;
-import com.twilio.auth_strategy.BasicAuthStrategy;
-import com.twilio.auth_strategy.TokenAuthStrategy;
 import com.twilio.constant.EnumConstants;
-import com.twilio.credential.ClientCredentialProvider;
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import lombok.Getter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class TwilioRestClient {

--- a/src/main/java/com/twilio/http/TwilioRestClient.java
+++ b/src/main/java/com/twilio/http/TwilioRestClient.java
@@ -12,7 +12,37 @@ import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+/**
+ * The `TwilioRestClient` class is responsible for making HTTP requests to the Twilio API.
+ * It provides methods to configure authentication, region, edge, and other settings
+ * required to interact with Twilio's services.
+ *
+ * <p>Features:</p>
+ * <ul>
+ *   <li>Supports basic authentication and token-based authentication strategies.</li>
+ *   <li>Allows configuration of custom HTTP clients and ObjectMapper for JSON processing.</li>
+ *   <li>Handles request retries for specific HTTP status codes (e.g., 401 Unauthorized).</li>
+ *   <li>Logs detailed request and response information for debugging purposes.</li>
+ * </ul>
+ *
+ * <p>Usage Example:</p>
+ * <pre>
+ * {@code
+ * TwilioRestClient client = new TwilioRestClient.Builder(ACCOUNT_SID, AUTH_TOKEN)
+ *           .objectMapper(customMapper)
+ *           .build();
+ *
+ * Message message = Message
+ *           .creator(
+ *               new PhoneNumber("+1xxxxxxxxxx"),
+ *               new PhoneNumber("+1xxxxxxxxxx"),
+ *               "This is the ship that made the Kessel Run in fourteen parsecs?"
+ *           ).create(client);
+ * }
+ * </pre>
+ *
+ * <p>Note: This class is designed to be thread-safe and reusable.</p>
+ */
 public class TwilioRestClient {
 
     public static final int HTTP_STATUS_CODE_CREATED = 201;

--- a/src/main/java/com/twilio/http/bearertoken/BearerTokenTwilioRestClient.java
+++ b/src/main/java/com/twilio/http/bearertoken/BearerTokenTwilioRestClient.java
@@ -44,23 +44,25 @@ public class BearerTokenTwilioRestClient {
         this.region = b.region;
         this.edge = b.edge;
         this.httpClient = b.httpClient;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = b.objectMapper;
         this.userAgentExtensions = b.userAgentExtensions;
         this.tokenManager = b.tokenManager;
+    }
 
+    public static class Builder {
         // This module configures the ObjectMapper to use
         // public API methods for manipulating java.time.*
         // classes. The alternative is to use reflection which
         // generates warnings from the module system on Java 9+
-        objectMapper.registerModule(new JavaTimeModule());
-    }
-    
-    public static class Builder {
+        private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
         private String region;
         private String edge;
         private BearerTokenHttpClient httpClient;
         private List<String> userAgentExtensions;
         private TokenManager tokenManager;
+        private ObjectMapper objectMapper = DEFAULT_OBJECT_MAPPER;
 
         public Builder() {
             this.region = System.getenv("TWILIO_REGION");
@@ -95,6 +97,11 @@ public class BearerTokenTwilioRestClient {
             return this;
         }
 
+        public BearerTokenTwilioRestClient.Builder objectMapper(final ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+            return this;
+        }
+
         public BearerTokenTwilioRestClient build() {
             if (this.httpClient == null) {
                 this.httpClient = new BearerTokenNetworkHttpClient();
@@ -111,7 +118,7 @@ public class BearerTokenTwilioRestClient {
                 }
             }
         }
-        
+
         request.setAuth(accessToken);
         if (region != null)
             request.setRegion(region);

--- a/src/main/java/com/twilio/http/noauth/NoAuthTwilioRestClient.java
+++ b/src/main/java/com/twilio/http/noauth/NoAuthTwilioRestClient.java
@@ -38,21 +38,23 @@ public class NoAuthTwilioRestClient {
         this.region = b.region;
         this.edge = b.edge;
         this.httpClient = b.httpClient;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = b.objectMapper;
         this.userAgentExtensions = b.userAgentExtensions;
+    }
 
+    public static class Builder {
         // This module configures the ObjectMapper to use
         // public API methods for manipulating java.time.*
         // classes. The alternative is to use reflection which
         // generates warnings from the module system on Java 9+
-        objectMapper.registerModule(new JavaTimeModule());
-    }
-    
-    public static class Builder {
+        private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
         private String region;
         private String edge;
         private NoAuthNetworkHttpClient httpClient;
         private List<String> userAgentExtensions;
+        private ObjectMapper objectMapper = DEFAULT_OBJECT_MAPPER;
 
         public Builder() {
             this.region = System.getenv("TWILIO_REGION");
@@ -79,6 +81,11 @@ public class NoAuthTwilioRestClient {
             if (userAgentExtensions != null && !userAgentExtensions.isEmpty()) {
                 this.userAgentExtensions = new ArrayList<>(userAgentExtensions);
             }
+            return this;
+        }
+
+        public NoAuthTwilioRestClient.Builder objectMapper(final ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
             return this;
         }
 

--- a/src/test/java/com/twilio/http/TwilioRestClientTest.java
+++ b/src/test/java/com/twilio/http/TwilioRestClientTest.java
@@ -1,18 +1,19 @@
 package com.twilio.http;
-import com.twilio.rest.Domains;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.twilio.rest.Domains;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
 
 public class TwilioRestClientTest {
     private TwilioRestClient twilioRestClient;
@@ -46,6 +47,20 @@ public class TwilioRestClientTest {
 
         Response resp = twilioRestClient.request(request);
         assertNotNull(resp);
+    }
+
+    @Test
+    public void testRequestWithCustomObjectMapper() {
+        Request request = new Request(
+                HttpMethod.GET,
+                Domains.API.toString(),
+                URI
+        );
+        twilioRestClientExtension = new TwilioRestClient.Builder(USER_NAME, TOKEN)
+                .objectMapper(new ObjectMapper().registerModule(new JavaTimeModule()))
+                .build();
+        twilioRestClientExtension.request(request);
+        assertEquals(userAgentStringExtensions, request.getUserAgentExtensions());
     }
 
     @Test


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

Adds support for providing a custom ObjectMapper to the rest client builders. If no ObjectMapper is provided to the builder, a default one which matches the existing configuration will be used. The default ObjectMapper for each rest client type will also now be held in a static variable, so we aren't instantiating a new one every time a rest client is created.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-java/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
