### PR TITLE
chore: openjdk error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM eclipse-temurin:8-jdk
 
 RUN mkdir /twilio
 WORKDIR /twilio


### PR DESCRIPTION
Moving from openjdk:8 to eclipse-temurin:8-jdk for dockerfile