### PR TITLE
chore: Remove duplicate maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,10 +443,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M4</version>
         <configuration>
           <forkCount>8</forkCount>


### PR DESCRIPTION
# Fixes #

This fixes the following message seen when building this project:

```sh
$ mvn test
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.twilio.sdk:twilio:jar:11.1.0 [WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-surefire-plugin @ line 447, column 15 [WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build. [WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects. [WARNING]
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-java/blob/main/CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
