### PR TITLE
fix: honor NetworkHttpClient RequestConfig in makeRequest

### DIFF
--- a/src/main/java/com/twilio/http/NetworkHttpClient.java
+++ b/src/main/java/com/twilio/http/NetworkHttpClient.java
@@ -45,6 +45,8 @@ public class NetworkHttpClient extends HttpClient {
 
     protected final CloseableHttpClient client;
 
+    private final RequestConfig requestConfig;
+
     private boolean isCustomClient;
 
     /**
@@ -70,6 +72,7 @@ public class NetworkHttpClient extends HttpClient {
      * @param socketConfig  a SocketConfig.
      */
     public NetworkHttpClient(final RequestConfig requestConfig, final SocketConfig socketConfig) {
+        this.requestConfig = requestConfig;
         Collection<BasicHeader> headers = Arrays.asList(
             new BasicHeader("X-Twilio-Client", "java-" + Twilio.VERSION),
             // The Accept header is intentionally omitted to support both SCIM and JSON content types.
@@ -109,6 +112,7 @@ public class NetworkHttpClient extends HttpClient {
      * @param clientBuilder an HttpClientBuilder.
      */
     public NetworkHttpClient(HttpClientBuilder clientBuilder) {
+        this.requestConfig = DEFAULT_REQUEST_CONFIG;
         Collection<BasicHeader> headers = Arrays.asList(
                 new BasicHeader("X-Twilio-Client", "java-" + Twilio.VERSION),
                 new BasicHeader(HttpHeaders.ACCEPT, "application/json"),
@@ -133,7 +137,9 @@ public class NetworkHttpClient extends HttpClient {
         HttpMethod method = request.getMethod();
         HttpUriRequestBase httpUriRequestBase = createHttpUriRequestBase(request);
 
-        httpUriRequestBase.setConfig(DEFAULT_REQUEST_CONFIG);
+        if (!isCustomClient) {
+            httpUriRequestBase.setConfig(this.requestConfig);
+        }
 
         httpUriRequestBase.setVersion(HttpVersion.HTTP_1_1);
 

--- a/src/test/java/com/twilio/http/NetworkHttpClientTest.java
+++ b/src/test/java/com/twilio/http/NetworkHttpClientTest.java
@@ -4,8 +4,11 @@ import com.twilio.constant.EnumConstants;
 import com.twilio.exception.ApiConnectionException;
 import com.twilio.http.IRequest.FormParameters;
 import com.twilio.http.IRequest.FormParameters.Type;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.util.Timeout;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -16,6 +19,9 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -372,6 +378,47 @@ public class NetworkHttpClientTest {
         assertEquals(201, response.getStatusCode());
         assertEquals("created", response.getContent());
 
+    }
+
+    @Test
+    public void testMakeRequestUsesConstructorRequestConfig() throws Exception {
+        RequestConfig customConfig = RequestConfig.custom()
+            .setResponseTimeout(Timeout.ofMilliseconds(12345))
+            .build();
+
+        CloseableHttpClient injectedClient = mock(CloseableHttpClient.class);
+        ArgumentCaptor<HttpUriRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpUriRequestBase.class);
+        when(injectedClient.execute(requestCaptor.capture())).thenReturn(mockResponse);
+        when(mockEntity.isRepeatable()).thenReturn(true);
+        when(mockEntity.getContentLength()).thenReturn(1L);
+        when(mockEntity.getContent()).thenReturn(new ByteArrayInputStream("ok".getBytes("UTF-8")));
+        when(mockResponse.getEntity()).thenReturn(mockEntity);
+        when(mockResponse.getCode()).thenReturn(200);
+
+        NetworkHttpClient clientWithConfig = new NetworkHttpClient(customConfig);
+        Field clientField = NetworkHttpClient.class.getDeclaredField("client");
+        clientField.setAccessible(true);
+        clientField.set(clientWithConfig, injectedClient);
+
+        when(mockRequest.getMethod()).thenReturn(HttpMethod.GET);
+        when(mockRequest.constructURL()).thenReturn(new URL("http://foo.com/hello"));
+        when(mockRequest.requiresAuthentication()).thenReturn(false);
+        when(mockRequest.getHeaderParams()).thenReturn(new HashMap<>());
+
+        clientWithConfig.makeRequest(mockRequest);
+
+        assertEquals(customConfig, requestCaptor.getValue().getConfig());
+    }
+
+    @Test
+    public void testCustomHttpClientBuilderDoesNotSetPerRequestConfig() throws IOException {
+        setup(200, "frobozz", HttpMethod.GET, false);
+
+        client.makeRequest(mockRequest);
+
+        ArgumentCaptor<HttpUriRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpUriRequestBase.class);
+        verify(mockClient).execute(requestCaptor.capture());
+        assertNull(requestCaptor.getValue().getConfig());
     }
 
 }


### PR DESCRIPTION
Fixes #913

`NetworkHttpClient(RequestConfig)` stores the caller's config on the Apache `HttpClientBuilder` via `setDefaultRequestConfig`, but `makeRequest` always called `httpUriRequestBase.setConfig(DEFAULT_REQUEST_CONFIG)`. Per-request config wins in HttpClient 5, so custom timeouts (e.g. response timeout) were silently ignored.

## Changes

- Store the constructor `RequestConfig` in a field (defaults to `DEFAULT_REQUEST_CONFIG` for the no-arg path).
- In `makeRequest`, apply `this.requestConfig` on each request instead of hardcoding `DEFAULT_REQUEST_CONFIG`.
- For `NetworkHttpClient(HttpClientBuilder)` (`isCustomClient=true`), skip per-request `setConfig` so builder-level defaults remain in effect.

## Test plan

- [x] `mvn test -Dtest=NetworkHttpClientTest` — 21 tests pass (JDK 17 / JBR 17.0.14, macOS darwin)
- [x] New `testMakeRequestUsesConstructorRequestConfig` — verifies a custom `RequestConfig` (12345 ms response timeout) is applied on the executed `HttpUriRequestBase`
- [x] New `testCustomHttpClientBuilderDoesNotSetPerRequestConfig` — verifies the `HttpClientBuilder` constructor path does not override per-request config
- [x] Confirmed both new tests fail on unfixed `main` (constructor config replaced by `DEFAULT_REQUEST_CONFIG`; custom builder path incorrectly received default config)

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-java/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified