### PR TITLE
fix: update javadoc outputDirectory for maven-javadoc-plugin 3.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,8 +466,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${javadoc.plugin.version}</version>
         <configuration>
-          <reportOutputDirectory>.</reportOutputDirectory>
-          <destDir>docs</destDir>
+          <outputDirectory>${project.basedir}/docs</outputDirectory>
           <source>8</source>
           <show>public</show>
           <nohelp>true</nohelp>


### PR DESCRIPTION
## Summary

- `reportOutputDirectory` and `destDir` were removed as unknown parameters in maven-javadoc-plugin 3.12.0 (bumped in commit `02dc16943` on 2026-07-31)
- Replace with `<outputDirectory>${project.basedir}/docs</outputDirectory>` which is the correct parameter in 3.12.0+
- Without this fix, `make docs` generates 0 HTML files

## Test plan

- [ ] Run `make docs` and verify HTML files are generated in `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)